### PR TITLE
[BUGFIX] Use correct format for email list used by Swift Mailer

### DIFF
--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailAddressMapper.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailAddressMapper.php
@@ -243,9 +243,7 @@ class EntityEmailAddressMapper
             if (empty($recipient['name'])) {
                 $emails[] = $recipient['email'];
             } else {
-                $emails[] = [
-                    $recipient['email'] => $recipient['name'],
-                ];
+                $emails[$recipient['email']] = $recipient['name'];
             }
         }
 


### PR DESCRIPTION
Fixes the case where an email/name combination was added to the list as
a new array entry.