### PR TITLE
[TASK] Mark method as deprecated for TYPO3 v8+

### DIFF
--- a/Classes/Definition/Tree/EventGroup/Event/Connection/Hook.php
+++ b/Classes/Definition/Tree/EventGroup/Event/Connection/Hook.php
@@ -100,6 +100,8 @@ class Hook extends AbstractDefinitionComponent implements Connection
 
     /**
      * @param Closure $closure
+     *
+     * @deprecated Must be removed when TYPO3 v7 is not supported anymore.
      */
     protected function injectHookInFrontendController(Closure $closure)
     {


### PR DESCRIPTION
The method `Hook::injectHookInFrontendController` is useless for TYPO3
v8+.