### PR TITLE
[BUGFIX] Use callable instead of closure in the event runner

### DIFF
--- a/Classes/Definition/Tree/EventGroup/Event/Connection/Signal.php
+++ b/Classes/Definition/Tree/EventGroup/Event/Connection/Signal.php
@@ -59,7 +59,7 @@ class Signal extends AbstractDefinitionComponent implements Connection
         $signalSlotDispatcher->connect(
             $this->className,
             $this->name,
-            $eventRunner->getCallable()
+            ...$eventRunner->getCallable()
         );
     }
 


### PR DESCRIPTION
Because a closure can't be serialized, an exception would be thrown in
some cases when TYPO3 slot dispatcher is somehow serialized (e.g. when
put in cache for some reason).

With this patch, the API does not work with closures anymore, and uses a
basic callable instead (resulting in the same process in the end).