### PR TITLE
[BUGFIX] Get correct select event value from TCA row data

### DIFF
--- a/Classes/Notification/Service/NotificationTcaService.php
+++ b/Classes/Notification/Service/NotificationTcaService.php
@@ -144,7 +144,10 @@ class NotificationTcaService implements SingletonInterface
 
         // We check if the record already exists in the database...
         if (MathUtility::canBeInterpretedAsInteger($row['uid'])) {
-            $eventValue = $row['event'][0];
+            // @PHP7
+            $eventValue = is_array($row['event'])
+                ? $row['event'][0]
+                : $row['event'];
 
             list($eventGroupIdentifier, $eventIdentifier) = GeneralUtility::trimExplode('.', $eventValue);
 


### PR DESCRIPTION
FormEngine may return the selected value from a single select element,
either as an array or as a string. Both cases must be handled.

It may be bound to https://forge.typo3.org/issues/82843