### PR TITLE
[FEATURE] Resolve mail template path from event identifier

### DIFF
--- a/Classes/Definition/Tree/EventGroup/Event/EventDefinition.php
+++ b/Classes/Definition/Tree/EventGroup/Event/EventDefinition.php
@@ -90,10 +90,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
      */
     public function getFullIdentifier()
     {
-        /** @var EventGroup $eventGroup */
-        $eventGroup = $this->getFirstParent(EventGroup::class);
-
-        return $eventGroup->getIdentifier() . '.' . $this->identifier;
+        return $this->getGroup()->getIdentifier() . '.' . $this->identifier;
     }
 
     /**
@@ -126,6 +123,17 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
     public function getConnection()
     {
         return $this->connection;
+    }
+
+    /**
+     * @return EventGroup
+     */
+    public function getGroup()
+    {
+        /** @var EventGroup $eventGroup */
+        $eventGroup = $this->getFirstParent(EventGroup::class);
+
+        return $eventGroup;
     }
 
     /**

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/View/View.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/View/View.php
@@ -36,6 +36,11 @@ class View extends AbstractDefinitionComponent implements DataPreProcessorInterf
     /**
      * @var array
      */
+    protected $templateRootPaths;
+
+    /**
+     * @var array
+     */
     protected $partialRootPaths;
 
     /**
@@ -76,6 +81,14 @@ class View extends AbstractDefinitionComponent implements DataPreProcessorInterf
     public function getLayoutRootPaths()
     {
         return $this->layoutRootPaths;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTemplateRootPaths()
+    {
+        return $this->templateRootPaths;
     }
 
     /**

--- a/Classes/Service/StringService.php
+++ b/Classes/Service/StringService.php
@@ -18,6 +18,7 @@ namespace CuyZ\Notiz\Service;
 
 use CuyZ\Notiz\Service\Traits\SelfInstantiateTrait;
 use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 class StringService implements SingletonInterface
 {
@@ -98,5 +99,14 @@ class StringService implements SingletonInterface
                 'email' => $email,
             ];
         }
+    }
+
+    /**
+     * @param string $string
+     * @return string
+     */
+    public function upperCamelCase($string)
+    {
+        return GeneralUtility::underscoredToUpperCamelCase(GeneralUtility::camelCaseToLowerCaseUnderscored($string));
     }
 }

--- a/Configuration/TypoScript/Notification/Entry/Notification.Email.typoscript
+++ b/Configuration/TypoScript/Notification/Entry/Notification.Email.typoscript
@@ -35,12 +35,13 @@ config {
                         layouts {
                             htmlDefault {
                                 label = Notification/Email/Entity:definition.view.layout.default.label
-                                path = Mail/Html/Default
+                                path = Html/Default
                             }
                         }
 
-                        layoutRootPaths.0 = EXT:notiz/Resources/Private/Layouts/
-                        partialRootPaths.0 = EXT:notiz/Resources/Private/Partials/
+                        layoutRootPaths.0 = EXT:notiz/Resources/Private/Layouts/Mail/
+                        templateRootPaths.0 = EXT:notiz/Resources/Private/Templates/Mail/
+                        partialRootPaths.0 = EXT:notiz/Resources/Private/Partials/Mail/
                     }
                 }
             }


### PR DESCRIPTION
The template file for a mail notification is not forced anymore to a
static path.

It now has two dynamic resolving methods:

- The identifier of both the dispatched event and its group are
  sanitized and used to guess a potential path.

  For instance, the template path for the event `myEvent` from the group
  `my_company` will be located at `MyCompany/MyEvent.html`.

- If the first method has no result, the template `Default` is used (one
  is provided by NotiZ but can be overridden).

To handle this new feature, a new definition entry has been added:
`notifications.entityEmail.settings.view.templateRootPaths` which can be
filled the classical way when working with Fluid templates.

Finally, the definition changed for both `layoutRootPaths` and
`partialRootPaths`: the folder `Mail` has been appended to the paths, to
mark it as the entry point for the template files.