### PR TITLE
[BUGFIX] Prevent full localization path from being returned

### DIFF
--- a/Classes/Service/LocalizationService.php
+++ b/Classes/Service/LocalizationService.php
@@ -111,7 +111,7 @@ class LocalizationService implements SingletonInterface
         foreach ($possiblePaths as $possiblePath) {
             $value = $this->localizeInternal($possiblePath, $arguments);
 
-            if ($value) {
+            if ($value && $value !== $possiblePath) {
                 return $value;
             }
         }


### PR DESCRIPTION
When the localization service has not been initialized yet, the value
returned is the full path to the translation key, not `null`. We need to
check that in order not to return a wrong value.