### PR TITLE
[FEATURE] Enhance `slot.render` view-helper

### DIFF
--- a/Classes/Core/Exception/EntryNotFoundException.php
+++ b/Classes/Core/Exception/EntryNotFoundException.php
@@ -42,8 +42,6 @@ class EntryNotFoundException extends NotizException
 
     const EVENT_CONNECTION_TYPE_MISSING = 'The property `type` must be filled with one of these values: `%s`.';
 
-    const SLOT_NOT_FOUND = 'The slot named `%s` was not found, please register it in the `Slots` section of your template.';
-
     /**
      * @param string $identifier
      * @return static
@@ -174,19 +172,6 @@ class EntryNotFoundException extends NotizException
             self::EVENT_CONNECTION_TYPE_MISSING,
             1509630193,
             [implode('`, `', $allowedTypes)]
-        );
-    }
-
-    /**
-     * @param string $name
-     * @return static
-     */
-    public static function slotNotFound($name)
-    {
-        return self::makeNewInstance(
-            self::SLOT_NOT_FOUND,
-            1517410382,
-            [$name]
         );
     }
 }

--- a/Classes/View/Slot/SlotView.php
+++ b/Classes/View/Slot/SlotView.php
@@ -18,7 +18,6 @@ namespace CuyZ\Notiz\View\Slot;
 
 use CuyZ\Notiz\Core\Definition\DefinitionService;
 use CuyZ\Notiz\Core\Definition\Tree\EventGroup\Event\EventDefinition;
-use CuyZ\Notiz\ViewHelpers\Slot\RenderViewHelper;
 use CuyZ\Notiz\ViewHelpers\Slot\SlotViewHelper;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
@@ -26,6 +25,10 @@ use TYPO3\CMS\Fluid\View\StandaloneView;
 
 class SlotView extends StandaloneView
 {
+    const SLOT_CONTAINER = 'SlotContainer';
+    const SLOT_VALUES = 'SlotValues';
+    const MARKERS = 'Marker';
+
     /**
      * @var SlotContainer
      */
@@ -92,9 +95,9 @@ class SlotView extends StandaloneView
     {
         $viewHelperVariableContainer = $this->baseRenderingContext->getViewHelperVariableContainer();
 
-        $viewHelperVariableContainer->add(RenderViewHelper::class, RenderViewHelper::SLOT_CONTAINER, $this->getSlots());
-        $viewHelperVariableContainer->add(RenderViewHelper::class, RenderViewHelper::SLOT_VALUES, $slotsValues);
-        $viewHelperVariableContainer->add(RenderViewHelper::class, RenderViewHelper::MARKERS, $markers);
+        $viewHelperVariableContainer->add(self::class, self::SLOT_CONTAINER, $this->getSlots());
+        $viewHelperVariableContainer->add(self::class, self::SLOT_VALUES, $slotsValues);
+        $viewHelperVariableContainer->add(self::class, self::MARKERS, $markers);
 
         return $this->render();
     }

--- a/Classes/ViewHelpers/Slot/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Slot/RenderViewHelper.php
@@ -16,39 +16,102 @@
 
 namespace CuyZ\Notiz\ViewHelpers\Slot;
 
+use Closure;
 use CuyZ\Notiz\Core\Exception\DuplicateEntryException;
-use CuyZ\Notiz\Core\Exception\EntryNotFoundException;
 use CuyZ\Notiz\Core\Property\Service\MarkerParser;
 use CuyZ\Notiz\Domain\Property\Marker;
+use CuyZ\Notiz\Service\Container;
 use CuyZ\Notiz\View\Slot\SlotContainer;
-use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractViewHelper;
+use CuyZ\Notiz\View\Slot\SlotView;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+use TYPO3\CMS\Fluid\Core\Compiler\TemplateCompiler;
+use TYPO3\CMS\Fluid\Core\Parser\SyntaxTree\AbstractNode;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\AbstractConditionViewHelper;
+use TYPO3\CMS\Fluid\Core\ViewHelper\ViewHelperVariableContainer;
 
-class RenderViewHelper extends AbstractViewHelper
+/**
+ * Will process and render the wanted slot, by getting the value filled by the
+ * user and replacing markers within it.
+ *
+ * This view-helper can be used in several ways:
+ *
+ * Inline
+ * ------
+ *
+ * The processed slot value will be returned.
+ *
+ * ```
+ * <nz:slot.render name="MySlot"
+ *                 markers="{foo: 'bar'}" />
+ * ```
+ *
+ * Conditional
+ * -----------
+ *
+ * Can be used to check whether the slot exists, and do something if it doesn't.
+ *
+ * When using this way, a variable `slotValue` becomes accessible within the
+ * view-helper, that contains the processed value of the slot. However, this
+ * variable is filled only when the slot exists and can be processed.
+ *
+ * ```
+ * <nz:slot.render name="SomeOptionalSlot">
+ *     <f:then>
+ *         {slotValue -> f:format.html()}
+ *     </f:then>
+ *     <f:else>
+ *         Some default value
+ *     </f:else>
+ * </nz:slot.render>
+ * ```
+ *
+ * Wrapping
+ * --------
+ *
+ * You may need to add HTML around the slot value only when the slot exists.
+ *
+ * ```
+ * <nz:slot.render name="SomeOptionalSlot">
+ *     <hr />
+ *
+ *     <div class="some-class">
+ *         {slotValue}
+ *     </div>
+ * </nz:slot.render>
+ * ```
+ */
+class RenderViewHelper extends AbstractConditionViewHelper
 {
-    const SLOT_CONTAINER = 'SlotContainer';
-    const SLOT_VALUES = 'SlotValues';
-    const MARKERS = 'Marker';
+    /**
+     * Unfortunately, the rendering context is not passed to the method
+     * `evaluateCondition`. We need to first save the variable container in the
+     * class before the method is called.
+     *
+     * @var ViewHelperVariableContainer
+     */
+    protected static $currentVariableContainer;
 
     /**
-     * @var MarkerParser
+     * @deprecated Must be removed when TYPO3 v7 is not supported anymore.
+     *
+     * @var AbstractNode[]
      */
-    protected $markerParser;
-
-    /**
-     * @param MarkerParser $markerParser
-     */
-    public function __construct(MarkerParser $markerParser)
-    {
-        $this->markerParser = $markerParser;
-    }
+    private $childNodesLegacy = [];
 
     /**
      * @inheritdoc
      */
     public function initializeArguments()
     {
+        parent::initializeArguments();
+
         $this->registerArgument('name', 'string', 'Name of the slot that will be rendered.', true);
         $this->registerArgument('markers', 'array', 'Additional markers that will be added to the slot and can be used within the FlexForm.', false, []);
+
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '8.0.0', '>=')) {
+            unset($this->argumentDefinitions['condition']);
+        }
     }
 
     /**
@@ -56,17 +119,74 @@ class RenderViewHelper extends AbstractViewHelper
      */
     public function render()
     {
-        $result = '';
-        $name = $this->arguments['name'];
-        $newMarkers = $this->arguments['markers'];
+        if (empty($this->childNodesLegacy)) {
+            return self::getSlotValue($this->arguments, $this->renderingContext);
+        } else {
+            self::addSlotValueToVariables($this->arguments, $this->renderingContext);
 
-        $slotContainer = $this->getSlotContainer();
-        $slotValues = $this->getSlotValues();
-        $markers = $this->getMarkers();
-
-        if (!$slotContainer->has($name)) {
-            throw EntryNotFoundException::slotNotFound($name);
+            return parent::render();
         }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public static function renderStatic(array $arguments, Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        self::addSlotValueToVariables($arguments, $renderingContext);
+
+        return parent::renderStatic($arguments, $renderChildrenClosure, $renderingContext);
+    }
+
+    /**
+     * Adds a new variable `slotValue` to the view, that contains the processed
+     * value of the slot.
+     *
+     * @param array $arguments
+     * @param RenderingContextInterface $renderingContext
+     */
+    protected static function addSlotValueToVariables(array $arguments, RenderingContextInterface $renderingContext)
+    {
+        $slotValue = self::getSlotValue($arguments, $renderingContext);
+        $renderingContext->getTemplateVariableContainer()->add('slotValue', $slotValue);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function compile($argumentsName, $closureName, &$initializationPhpCode, AbstractNode $node, TemplateCompiler $compiler)
+    {
+        if (empty($node->getChildNodes())) {
+            return sprintf(
+                '%s::getSlotValue(%s, $renderingContext)',
+                get_class($this),
+                $argumentsName
+            );
+        } else {
+            return parent::compile($argumentsName, $closureName, $initializationPhpCode, $node, $compiler);
+        }
+    }
+
+    /**
+     * Fetches the final value of the wanted slot, by getting the user value and
+     * replacing markers in it.
+     *
+     * @param array $arguments
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     *
+     * @throws DuplicateEntryException
+     */
+    public static function getSlotValue(array $arguments, RenderingContextInterface $renderingContext)
+    {
+        self::$currentVariableContainer = $renderingContext->getViewHelperVariableContainer();
+
+        $result = '';
+        $name = $arguments['name'];
+        $newMarkers = $arguments['markers'];
+
+        $slotValues = self::getSlotValues();
+        $markers = self::getMarkers();
 
         foreach ($newMarkers as $key => $value) {
             if (isset($markers[$key])) {
@@ -82,37 +202,59 @@ class RenderViewHelper extends AbstractViewHelper
                 $markers[$key] = $marker;
             }
 
-            $result = $this->markerParser->replaceMarkers(
+            $markerParser = Container::get(MarkerParser::class);
+
+            $result = $markerParser->replaceMarkers(
                 $slotValues[$name],
                 $markers
             );
         }
 
-
         return $result;
+    }
+
+    /**
+     * @param array $arguments
+     * @return bool
+     */
+    protected static function evaluateCondition($arguments = null)
+    {
+        return self::getSlotContainer()->has($arguments['name']);
+    }
+
+    /**
+     * @deprecated Must be removed when TYPO3 v7 is not supported anymore.
+     *
+     * @param array $childNodes
+     */
+    public function setChildNodes(array $childNodes)
+    {
+        $this->childNodesLegacy = $childNodes;
+
+        parent::setChildNodes($childNodes);
     }
 
     /**
      * @return SlotContainer
      */
-    protected function getSlotContainer()
+    protected static function getSlotContainer()
     {
-        return $this->viewHelperVariableContainer->get(__CLASS__, self::SLOT_CONTAINER);
+        return self::$currentVariableContainer->get(SlotView::class, SlotView::SLOT_CONTAINER);
     }
 
     /**
      * @return array
      */
-    protected function getSlotValues()
+    protected static function getSlotValues()
     {
-        return $this->viewHelperVariableContainer->get(__CLASS__, self::SLOT_VALUES);
+        return self::$currentVariableContainer->get(SlotView::class, SlotView::SLOT_VALUES);
     }
 
     /**
      * @return array
      */
-    protected function getMarkers()
+    protected static function getMarkers()
     {
-        return $this->viewHelperVariableContainer->get(__CLASS__, self::MARKERS);
+        return self::$currentVariableContainer->get(SlotView::class, SlotView::MARKERS);
     }
 }

--- a/Classes/ViewHelpers/Slot/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Slot/RenderViewHelper.php
@@ -148,6 +148,14 @@ class RenderViewHelper extends AbstractConditionViewHelper
     protected static function addSlotValueToVariables(array $arguments, RenderingContextInterface $renderingContext)
     {
         $slotValue = self::getSlotValue($arguments, $renderingContext);
+
+        /**
+         * @deprecated Must be removed when TYPO3 v7 is not supported anymore.
+         */
+        if ($renderingContext->getTemplateVariableContainer()->exists('slotValue')) {
+            $renderingContext->getTemplateVariableContainer()->remove('slotValue');
+        }
+
         $renderingContext->getTemplateVariableContainer()->add('slotValue', $slotValue);
     }
 

--- a/Documentation/Notifications/Email/Customize-email-body.md
+++ b/Documentation/Notifications/Email/Customize-email-body.md
@@ -126,8 +126,58 @@ And here is the received email:
 >  * New products (subscribed on 31/01/2018): Information about out new products
 >  * Discounts (subscribed on 28/01/2018): Get discounts on existing products
 
-[slots-example]: /Documentation/Images/EmailNotification/email-slots.png
+## Use advanced slot rendering
+
+When a slot is rendered, the value filled by the user (in the notification 
+record) is fetched and processed with the available markers (coming from the 
+event).
+
+The slot rendering can be used in several ways:
+
+### Default
+
+If you just want to render the processed value, just call the view-helper:
+
+```html
+<f:section name="Body">
+    <nz:slot.render name="MySlot" />
+</f:section>
+``` 
+
+### Conditional rendering
+
+If a given slot may be unregistered, you can use the view-helper like a 
+classical conditional Fluid view-helper. In this case, a new Fluid variable 
+containing the processed value is accessible: `{slotValue}` 
+
+```html
+<f:section name="Body">
+    <nz:slot.render name="MySlot">
+        <f:then>{slotValue}</f:then>
+        <f:else>Default value</f:else>
+    </nz:slot.render>
+</f:section>
+```
+
+### Wrapping
+
+You can also use the view-helper as a wrapper for the slot value. In that case,
+if the slot is not registered nothing will be rendered.
+
+```html
+<f:section name="Body">
+    <nz:slot.render name="MySlot">
+        <hr />
+        
+        <div class="my-class">
+            {slotValue -> f:format.html()}
+        </div>
+    </nz:slot.render>
+</f:section>
+```
 
 ---
 
 [:books: Documentation index](../../README.md)
+
+[slots-example]: /Documentation/Images/EmailNotification/email-slots.png


### PR DESCRIPTION
This view-helper can now use two new features, for a total of three ways
to render a slot.

Inline
------

The processed slot value will be returned.

```html
<nz:slot.render name="MySlot"
                markers="{foo: 'bar'}" />
```

Conditional
-----------

Can be used to check whether the slot exists, and do something if it
doesn't. When using this way, a variable `slotValue` becomes accessible
within the view-helper, that contains the processed value of the slot.
However, this variable is filled only when the slot exists and can be
processed.

```html
<nz:slot.render name="SomeOptionalSlot">
    <f:then>
        {slotValue -> f:format.html()}
    </f:then>
    <f:else>
        Some default value
    </f:else>
</nz:slot.render>
```

Wrapping
--------

You may need to add HTML around the slot value only when the slot
exists.

```html
<nz:slot.render name="SomeOptionalSlot">
    <hr />
    <div class="some-class">
        {slotValue}
    </div>
</nz:slot.render>
```