### PR TITLE
[!!!][TASK] Change definition namespace

### DIFF
--- a/Classes/Domain/Definition/Builder/Component/Source/TypoScriptDefinitionSource.php
+++ b/Classes/Domain/Definition/Builder/Component/Source/TypoScriptDefinitionSource.php
@@ -22,7 +22,6 @@ use CuyZ\Notiz\Support\NotizConstants;
 use Romm\ConfigurationObject\ConfigurationObjectInstance;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser;
-use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Service\TypoScriptService;
 
@@ -125,8 +124,8 @@ class TypoScriptDefinitionSource implements DefinitionSource, SingletonInterface
 
         $definition = $this->typoScriptService->convertTypoScriptArrayToPlainArray($typoScriptParser->setup);
 
-        return ArrayUtility::isValidPath($definition, NotizConstants::DEFINITION_ROOT_PATH, '.')
-            ? ArrayUtility::getValueByPath($definition, NotizConstants::DEFINITION_ROOT_PATH, '.')
+        return isset($definition[NotizConstants::DEFINITION_ROOT_PATH])
+            ? $definition[NotizConstants::DEFINITION_ROOT_PATH]
             : [];
     }
 }

--- a/Classes/Support/NotizConstants.php
+++ b/Classes/Support/NotizConstants.php
@@ -54,7 +54,7 @@ final class NotizConstants
     /**
      * Used to retrieve the FrontendCache instance.
      */
-    const CACHE_ID = 'notiz';
+    const CACHE_ID = self::EXTENSION_KEY;
 
     /**
      * Cache key used by the `configuration_object` API for NotiZ.
@@ -64,7 +64,7 @@ final class NotizConstants
     /**
      * Root node for all definitions.
      */
-    const DEFINITION_ROOT_PATH = 'config.tx_' . self::EXTENSION_KEY;
+    const DEFINITION_ROOT_PATH = self::EXTENSION_KEY;
 
     /**
      * Identifier for the administration backend module. Can be used for:

--- a/Configuration/TypoScript/Channel/Channels.Default.typoscript
+++ b/Configuration/TypoScript/Channel/Channels.Default.typoscript
@@ -1,18 +1,16 @@
-config {
-    tx_notiz {
-        channels {
-            email {
-                typo3 {
-                    className = CuyZ\Notiz\Domain\Channel\Email\TYPO3\EmailChannel
-                    label = Channel/Email/TYPO3-Email:title
-                }
+notiz {
+    channels {
+        email {
+            typo3 {
+                className = CuyZ\Notiz\Domain\Channel\Email\TYPO3\EmailChannel
+                label = Channel/Email/TYPO3-Email:title
             }
+        }
 
-            logs {
-                typo3 {
-                    className = CuyZ\Notiz\Domain\Channel\Log\Typo3LogChannel
-                    label = Channel/Log/TYPO3-Log:title
-                }
+        logs {
+            typo3 {
+                className = CuyZ\Notiz\Domain\Channel\Log\Typo3LogChannel
+                label = Channel/Log/TYPO3-Log:title
             }
         }
     }

--- a/Configuration/TypoScript/Event/Events.Scheduler.typoscript
+++ b/Configuration/TypoScript/Event/Events.Scheduler.typoscript
@@ -1,60 +1,58 @@
-config {
-    tx_notiz {
-        eventGroups {
-            scheduler {
-                label = LLL:EXT:scheduler/Resources/Private/Language/locallang_mod.xlf:mlang_labels_tablabel
+notiz {
+    eventGroups {
+        scheduler {
+            label = LLL:EXT:scheduler/Resources/Private/Language/locallang_mod.xlf:mlang_labels_tablabel
 
-                events {
-                    /*
-                    * Scheduler task was executed
-                    * ---------------------------
-                    *
-                    * Event firing when a scheduler task was executed without
-                    * error.
-                    */
-                    schedulerTaskWasExecuted {
-                        label = Event/Scheduler/SchedulerTaskWasExecuted:title
+            events {
+                /*
+                * Scheduler task was executed
+                * ---------------------------
+                *
+                * Event firing when a scheduler task was executed without
+                * error.
+                */
+                schedulerTaskWasExecuted {
+                    label = Event/Scheduler/SchedulerTaskWasExecuted:title
 
-                        className = CuyZ\Notiz\Domain\Event\Scheduler\SchedulerTaskWasExecutedEvent
+                    className = CuyZ\Notiz\Domain\Event\Scheduler\SchedulerTaskWasExecutedEvent
 
-                        configuration {
-                            flexForm {
-                                file = EXT:notiz/Configuration/FlexForm/Event/Scheduler/SchedulerTaskEventFlexForm.xml
-                            }
-                        }
-
-                        connection {
-                            type = signal
-
-                            className = CuyZ\Notiz\Service\Scheduler\Scheduler
-                            name = taskWasExecuted
+                    configuration {
+                        flexForm {
+                            file = EXT:notiz/Configuration/FlexForm/Event/Scheduler/SchedulerTaskEventFlexForm.xml
                         }
                     }
 
-                    /*
-                    * Scheduler task execution failed
-                    * -------------------------------
-                    *
-                    * Event firing when an exception/error was thrown during the
-                    * execution of a scheduler task.
-                    */
-                    schedulerTaskExecutionFailed {
-                        label = Event/Scheduler/SchedulerTaskExecutionFailed:title
+                    connection {
+                        type = signal
 
-                        className = CuyZ\Notiz\Domain\Event\Scheduler\SchedulerTaskExecutionFailedEvent
+                        className = CuyZ\Notiz\Service\Scheduler\Scheduler
+                        name = taskWasExecuted
+                    }
+                }
 
-                        configuration {
-                            flexForm {
-                                file = EXT:notiz/Configuration/FlexForm/Event/Scheduler/SchedulerTaskEventFlexForm.xml
-                            }
+                /*
+                * Scheduler task execution failed
+                * -------------------------------
+                *
+                * Event firing when an exception/error was thrown during the
+                * execution of a scheduler task.
+                */
+                schedulerTaskExecutionFailed {
+                    label = Event/Scheduler/SchedulerTaskExecutionFailed:title
+
+                    className = CuyZ\Notiz\Domain\Event\Scheduler\SchedulerTaskExecutionFailedEvent
+
+                    configuration {
+                        flexForm {
+                            file = EXT:notiz/Configuration/FlexForm/Event/Scheduler/SchedulerTaskEventFlexForm.xml
                         }
+                    }
 
-                        connection {
-                            type = signal
+                    connection {
+                        type = signal
 
-                            className = CuyZ\Notiz\Service\Scheduler\Scheduler
-                            name = taskExecutionFailed
-                        }
+                        className = CuyZ\Notiz\Service\Scheduler\Scheduler
+                        name = taskExecutionFailed
                     }
                 }
             }

--- a/Configuration/TypoScript/Event/Events.TYPO3.typoscript
+++ b/Configuration/TypoScript/Event/Events.TYPO3.typoscript
@@ -1,55 +1,53 @@
-config {
-    tx_notiz {
-        eventGroups {
-            /*
-             * List of events that are part of the TYPO3 core and may be fired
-             * in any default TYPO3 instance.
-             */
-            typo3 {
-                label = TYPO3
+notiz {
+    eventGroups {
+        /*
+         * List of events that are part of the TYPO3 core and may be fired
+         * in any default TYPO3 instance.
+         */
+        typo3 {
+            label = TYPO3
 
-                events {
-                    /*
-                     * EXTENSION INSTALLED
-                     * -------------------
-                     *
-                     * Event firing whenever a TYPO3 extension is installed.
-                     */
-                    extensionInstalled {
-                        label = Event/TYPO3/ExtensionInstalled:title
+            events {
+                /*
+                 * EXTENSION INSTALLED
+                 * -------------------
+                 *
+                 * Event firing whenever a TYPO3 extension is installed.
+                 */
+                extensionInstalled {
+                    label = Event/TYPO3/ExtensionInstalled:title
 
-                        className = CuyZ\Notiz\Domain\Event\TYPO3\ExtensionInstalledEvent
+                    className = CuyZ\Notiz\Domain\Event\TYPO3\ExtensionInstalledEvent
 
-                        connection {
-                            type = signal
+                    connection {
+                        type = signal
 
-                            className = TYPO3\CMS\Extensionmanager\Service\ExtensionManagementService
-                            name = hasInstalledExtensions
+                        className = TYPO3\CMS\Extensionmanager\Service\ExtensionManagementService
+                        name = hasInstalledExtensions
+                    }
+                }
+
+                /*
+                 * CACHES CLEARED
+                 * --------------
+                 *
+                 * Event firing whenever the TYPO3 caches are cleared.
+                 */
+                cachesCleared {
+                    label = Event/TYPO3/CacheCleared:title
+
+                    className = CuyZ\Notiz\Domain\Event\TYPO3\CachesClearedEvent
+
+                    configuration {
+                        flexForm {
+                            file = EXT:notiz/Configuration/FlexForm/Event/TYPO3/CachesClearedEventFlexForm.xml
                         }
                     }
 
-                    /*
-                     * CACHES CLEARED
-                     * --------------
-                     *
-                     * Event firing whenever the TYPO3 caches are cleared.
-                     */
-                    cachesCleared {
-                        label = Event/TYPO3/CacheCleared:title
+                    connection {
+                        type = hook
 
-                        className = CuyZ\Notiz\Domain\Event\TYPO3\CachesClearedEvent
-
-                        configuration {
-                            flexForm {
-                                file = EXT:notiz/Configuration/FlexForm/Event/TYPO3/CachesClearedEventFlexForm.xml
-                            }
-                        }
-
-                        connection {
-                            type = hook
-
-                            path = t3lib/class.t3lib_tcemain.php|clearCachePostProc
-                        }
+                        path = t3lib/class.t3lib_tcemain.php|clearCachePostProc
                     }
                 }
             }

--- a/Configuration/TypoScript/Notification/Entry/Notification.Email.typoscript
+++ b/Configuration/TypoScript/Notification/Entry/Notification.Email.typoscript
@@ -1,48 +1,46 @@
-config {
-    tx_notiz {
-        notifications {
-            entityEmail {
-                label = Notification/Email/Entity:title
+notiz {
+    notifications {
+        entityEmail {
+            label = Notification/Email/Entity:title
 
-                className = CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\EntityEmailNotification
+            className = CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\EntityEmailNotification
 
-                iconPath = EXT:notiz/Resources/Public/Icon/Notification/notification-email-entity-typo3.svg
+            iconPath = EXT:notiz/Resources/Public/Icon/Notification/notification-email-entity-typo3.svg
 
-                channels < config.tx_notiz.channels.email
+            channels < notiz.channels.email
 
-                settings {
-                    defaultSender = no-reply@example.org
+            settings {
+                defaultSender = no-reply@example.org
 
+                /*
+                 * Global recipients will be available for every mail
+                 * notification.
+                 *
+                 * It should contain a list of administrators or mailing
+                 * lists.
+                 *
+                 * See examples below.
+                 */
+                globalRecipients {
+                    # 10 = John Smith <john.smith@example.com>
+                    # 20 = jane.smith@example.com
+                }
+
+                view {
                     /*
-                     * Global recipients will be available for every mail
-                     * notification.
-                     *
-                     * It should contain a list of administrators or mailing
-                     * lists.
-                     *
-                     * See examples below.
+                     * List of layouts that can be used by email
+                     * notifications.
                      */
-                    globalRecipients {
-                        # 10 = John Smith <john.smith@example.com>
-                        # 20 = jane.smith@example.com
-                    }
-
-                    view {
-                        /*
-                         * List of layouts that can be used by email
-                         * notifications.
-                         */
-                        layouts {
-                            htmlDefault {
-                                label = Notification/Email/Entity:definition.view.layout.default.label
-                                path = Html/Default
-                            }
+                    layouts {
+                        htmlDefault {
+                            label = Notification/Email/Entity:definition.view.layout.default.label
+                            path = Html/Default
                         }
-
-                        layoutRootPaths.0 = EXT:notiz/Resources/Private/Layouts/Mail/
-                        templateRootPaths.0 = EXT:notiz/Resources/Private/Templates/Mail/
-                        partialRootPaths.0 = EXT:notiz/Resources/Private/Partials/Mail/
                     }
+
+                    layoutRootPaths.0 = EXT:notiz/Resources/Private/Layouts/Mail/
+                    templateRootPaths.0 = EXT:notiz/Resources/Private/Templates/Mail/
+                    partialRootPaths.0 = EXT:notiz/Resources/Private/Partials/Mail/
                 }
             }
         }

--- a/Configuration/TypoScript/Notification/Entry/Notification.Log.typoscript
+++ b/Configuration/TypoScript/Notification/Entry/Notification.Log.typoscript
@@ -1,15 +1,13 @@
-config {
-    tx_notiz {
-        notifications {
-            entityLog {
-                label = Notification/Log/Entity:title
+notiz {
+    notifications {
+        entityLog {
+            label = Notification/Log/Entity:title
 
-                className = CuyZ\Notiz\Domain\Notification\Log\Application\EntityLog\EntityLogNotification
+            className = CuyZ\Notiz\Domain\Notification\Log\Application\EntityLog\EntityLogNotification
 
-                iconPath = EXT:notiz/Resources/Public/Icon/Notification/notification-log-entity-typo3.svg
+            iconPath = EXT:notiz/Resources/Public/Icon/Notification/notification-log-entity-typo3.svg
 
-                channels < config.tx_notiz.channels.logs
-            }
+            channels < notiz.channels.logs
         }
     }
 }

--- a/Documentation/Events/Create-a-custom-event.md
+++ b/Documentation/Events/Create-a-custom-event.md
@@ -60,24 +60,22 @@ For example `$name` can be used as `#NAME#`.
 Events are registered in Typoscript:
 
 ```typoscript
-config {
-    tx_notiz {
-        eventGroups {
-            contactEvents {
-                label = Events related to contact forms
+notiz {
+    eventGroups {
+        contactEvents {
+            label = Events related to contact forms
 
-                events {
-                    messageSent {
-                        label = Contact form sent
+            events {
+                messageSent {
+                    label = Contact form sent
 
-                        className = Acme\MyExtension\Domain\Event\ContactFormSentEvent
+                    className = Acme\MyExtension\Domain\Event\ContactFormSentEvent
 
-                        connection {
-                            type = signal
+                    connection {
+                        type = signal
 
-                            className = Acme\MyExtension\Controller\ContactController
-                            name = sendMessage
-                        }
+                        className = Acme\MyExtension\Controller\ContactController
+                        name = sendMessage
                     }
                 }
             }

--- a/Documentation/Installation/Add-TypoScript-definition.md
+++ b/Documentation/Installation/Add-TypoScript-definition.md
@@ -58,53 +58,51 @@ Finally, you can write definition in your newly registered file:
 
 > *`my_extension/Configuration/TypoScript/MyCustomDefinition.typoscript`*
 ```
-config {
-    tx_notiz {
-        notifications {
-            /*
-             * Modifying the provided email notification settings…
-             */
-            entityEmail {
-                settings {
-                    /*
-                     * These recipients will be available by default in every 
-                     * email notification record.
-                     */
-                    globalRecipients {
-                         10 = webmaster@acme.com
-                    }
+notiz {
+    notifications {
+        /*
+         * Modifying the provided email notification settings…
+         */
+        entityEmail {
+            settings {
+                /*
+                 * These recipients will be available by default in every 
+                 * email notification record.
+                 */
+                globalRecipients {
+                     10 = webmaster@acme.com
                 }
             }
         }
-        
-        eventGroups {
-            /*
-             * We add a new event group for our custom events.
-             */
-            my_extension {
-                label = Events for My Extension
+    }
+    
+    eventGroups {
+        /*
+         * We add a new event group for our custom events.
+         */
+        my_extension {
+            label = Events for My Extension
 
-                events {
-                    /*
-                     * Contact form is sent
-                     * --------------------
-                     *
-                     * This event is bound to a signal sent by the contact 
-                     * controller. It contains data about the user who submitted
-                     * the form, that will be available in the notifications
-                     * markers.
-                     */
-                    copieSauvegardeSimulateur {
-                        label = Contact form sent
+            events {
+                /*
+                 * Contact form is sent
+                 * --------------------
+                 *
+                 * This event is bound to a signal sent by the contact 
+                 * controller. It contains data about the user who submitted
+                 * the form, that will be available in the notifications
+                 * markers.
+                 */
+                copieSauvegardeSimulateur {
+                    label = Contact form sent
 
-                        className = MyVendor\MyExtension\Event\ContactFormSentEvent
+                    className = MyVendor\MyExtension\Event\ContactFormSentEvent
 
-                        connection {
-                            type = signal
+                    connection {
+                        type = signal
 
-                            className = MyVendor\MyContactExtension\Controller\ContactController
-                            name = contactFormSent
-                        }
+                        className = MyVendor\MyContactExtension\Controller\ContactController
+                        name = contactFormSent
                     }
                 }
             }

--- a/Documentation/Notifications/Email/Customize-email-body.md
+++ b/Documentation/Notifications/Email/Customize-email-body.md
@@ -20,18 +20,16 @@ to be transformed to the UpperCamelCase syntax.
 For instance, let's take the example below:
 
 ```typoscript
-config {
-    tx_notiz {
-        eventGroups {
-            contactEvents {
-                label = Events related to contact forms
+notiz {
+    eventGroups {
+        contactEvents {
+            label = Events related to contact forms
 
-                events {
-                    messageSent {
-                        label = Contact form sent
+            events {
+                messageSent {
+                    label = Contact form sent
 
-                        // Other stuf…
-                    }
+                    // Other stuf…
                 }
             }
         }
@@ -47,15 +45,13 @@ Also remember to register the template paths to your extension. You can do so in
 the definition of the mail notification:
 
 ```typoscript
-config {
-    tx_notiz {
-        notifications {
-            entityEmail {
-                view {
-                    layoutRootPaths.50 = EXT:my_extension/Resources/Private/Layouts/Mail/
-                    templateRootPaths.50 = EXT:my_extension/Resources/Private/Templates/Mail/
-                    partialRootPaths.50 = EXT:my_extension/Resources/Private/Partials/Mail/
-                }
+notiz {
+    notifications {
+        entityEmail {
+            view {
+                layoutRootPaths.50 = EXT:my_extension/Resources/Private/Layouts/Mail/
+                templateRootPaths.50 = EXT:my_extension/Resources/Private/Templates/Mail/
+                partialRootPaths.50 = EXT:my_extension/Resources/Private/Partials/Mail/
             }
         }
     }

--- a/Documentation/Notifications/Email/README.md
+++ b/Documentation/Notifications/Email/README.md
@@ -60,7 +60,7 @@ You can also define globally available recipients that you can then use in
 any of your notifications.
 
 They are configurable in TypoScript at the path:
-`config.tx_notiz.notifications.entityEmail.settings.globalRecipients`.
+`notiz.notifications.entityEmail.settings.globalRecipients`.
 
 This is useful for recipients that are shared between several notifications.
 
@@ -70,7 +70,7 @@ This is useful for recipients that are shared between several notifications.
 ## Sender
 
 The default sender is configurable in TypoScript at the path:
-`config.tx_notiz.notifications.entityEmail.settings.defaultSender`.
+`notiz.notifications.entityEmail.settings.defaultSender`.
 You can also override it by notification.
 
 ![Sender tab][tab-sender]


### PR DESCRIPTION
The namespace root for NotiZ definition has been changed from
`config.tx_notiz` to `notiz`

For instance, events may now be added to the definition by using the
following namespace: `notiz.eventGroups.myGroup.events.myEvent`

Closes #28