### PR TITLE
[FEATURE] Allow RTE mode in text slot

### DIFF
--- a/Classes/Notification/Service/NotificationTcaService.php
+++ b/Classes/Notification/Service/NotificationTcaService.php
@@ -225,6 +225,23 @@ HTML;
     }
 
     /**
+     * If a RTE is using a missing CKEditor preset, a message is shown to the
+     * user to help him fix it.
+     *
+     * @param array $parent
+     * @return string
+     */
+    public function showCKEditorPresetMissing(array $parent)
+    {
+        $preset = $parent['parameters']['preset'];
+
+        $message = LocalizationService::localize('Notification/Entity/Fields:field.rte.ck_editor_preset_missing', [$preset]);
+        $message = StringService::mark($message, '<code>$1</code>');
+
+        return '<span class="bg-danger">' . $message . '</span>';
+    }
+
+    /**
      * @param array $array
      * @param $label
      */

--- a/Classes/Service/StringService.php
+++ b/Classes/Service/StringService.php
@@ -30,11 +30,12 @@ class StringService implements SingletonInterface
      * @see \CuyZ\Notiz\Service\StringService::doMark
      *
      * @param string $content
+     * @param string $replacement
      * @return string
      */
-    public static function mark($content)
+    public static function mark($content, $replacement = '<samp class="bg-info">$1</samp>')
     {
-        return self::get()->doMark($content);
+        return self::get()->doMark($content, $replacement);
     }
 
     /**
@@ -50,13 +51,14 @@ class StringService implements SingletonInterface
      * > Look at <samp class="bg-info">foo</samp> lorem ipsum...
      *
      * @param string $content
+     * @param string $replacement
      * @return string
      */
-    public function doMark($content)
+    public function doMark($content, $replacement)
     {
         return preg_replace(
             '/`([^`]+)`/',
-            '<samp class="bg-info">$1</samp>',
+            $replacement,
             $content
         );
     }

--- a/Classes/View/Slot/Application/Slot.php
+++ b/Classes/View/Slot/Application/Slot.php
@@ -66,4 +66,12 @@ abstract class Slot
      * @return string
      */
     abstract public function getFlexFormConfiguration();
+
+    /**
+     * @return string
+     */
+    public function getFlexFormAdditionalConfiguration()
+    {
+        return '';
+    }
 }

--- a/Classes/View/Slot/Application/TextSlot.php
+++ b/Classes/View/Slot/Application/TextSlot.php
@@ -16,17 +16,94 @@
 
 namespace CuyZ\Notiz\View\Slot\Application;
 
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
 class TextSlot extends Slot
 {
+    /**
+     * @var bool
+     */
+    protected $rte;
+
+    /**
+     * The RTE mode that can be used for:
+     *
+     * - CKEditor: must contain a valid preset that was registered in the global
+     *             configuration of the extension.
+     * - RTEHtmlArea: extra configuration for the RTE (field `defaultExtras`).
+     *
+     * @var string
+     */
+    protected $rteMode;
+
+    /**
+     * @param string $name
+     * @param string $label
+     * @param bool $rte
+     * @param string $rteMode
+     */
+    public function __construct($name, $label, $rte, $rteMode)
+    {
+        parent::__construct($name, $label);
+
+        $this->rte = $rte;
+        $this->rteMode = $rteMode;
+    }
+
     /**
      * @return string
      */
     public function getFlexFormConfiguration()
     {
-        return <<<XML
-    <type>text</type>
-    <cols>40</cols>
-    <rows>15</rows>
-XML;
+        $flexForm = '
+            <type>text</type>
+            <cols>40</cols>
+            <rows>15</rows>';
+
+        if ($this->rte) {
+            $flexForm .= '<enableRichtext>1</enableRichtext>';
+
+            if ($this->rteMode
+                && !$this->isUsingLegacyRte()
+            ) {
+                if (!isset($GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets'][$this->rteMode])) {
+                    $flexForm = "
+                        <type>user</type>
+                        <userFunc>CuyZ\Notiz\Notification\Service\NotificationTcaService->showCKEditorPresetMissing</userFunc>
+                        <parameters>
+                            <preset>$this->rteMode</preset>
+                        </parameters>";
+                } else {
+                    $flexForm .= "<richtextConfiguration>$this->rteMode</richtextConfiguration>";
+                }
+            }
+        }
+
+        return $flexForm;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFlexFormAdditionalConfiguration()
+    {
+        $flexForm = '';
+
+        if ($this->rteMode
+            && $this->isUsingLegacyRte()
+        ) {
+            $flexForm .= "<defaultExtras>$this->rteMode</defaultExtras>";
+        }
+
+        return $flexForm;
+    }
+
+    /**
+     * @return bool
+     */
+    private function isUsingLegacyRte()
+    {
+        return ExtensionManagementUtility::isLoaded('rtehtmlarea')
+            && !ExtensionManagementUtility::isLoaded('rte_ckeditor');
     }
 }

--- a/Classes/View/Slot/Application/TextSlot.php
+++ b/Classes/View/Slot/Application/TextSlot.php
@@ -60,26 +60,32 @@ class TextSlot extends Slot
             <cols>40</cols>
             <rows>15</rows>';
 
-        if ($this->rte) {
-            $flexForm .= '<enableRichtext>1</enableRichtext>';
-
-            if ($this->rteMode
-                && !$this->isUsingLegacyRte()
-            ) {
-                if (!isset($GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets'][$this->rteMode])) {
-                    $flexForm = "
-                        <type>user</type>
-                        <userFunc>CuyZ\Notiz\Notification\Service\NotificationTcaService->showCKEditorPresetMissing</userFunc>
-                        <parameters>
-                            <preset>$this->rteMode</preset>
-                        </parameters>";
-                } else {
-                    $flexForm .= "<richtextConfiguration>$this->rteMode</richtextConfiguration>";
-                }
-            }
+        if (!$this->rte) {
+            return $flexForm;
         }
 
-        return $flexForm;
+        $flexForm .= '<enableRichtext>1</enableRichtext>';
+
+        if (!$this->rteMode
+            || $this->isUsingLegacyRte()
+        ) {
+            return $flexForm;
+        }
+
+        if (isset($GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets'][$this->rteMode])) {
+            return $flexForm . "<richtextConfiguration>$this->rteMode</richtextConfiguration>";
+        }
+
+        /*
+         * If we get to here, the CKEditor preset was not found: we warn the
+         * user about it.
+         */
+        return "
+                <type>user</type>
+                <userFunc>CuyZ\Notiz\Notification\Service\NotificationTcaService->showCKEditorPresetMissing</userFunc>
+                <parameters>
+                    <preset>$this->rteMode</preset>
+                </parameters>";
     }
 
     /**

--- a/Classes/View/Slot/Service/SlotFlexFormService.php
+++ b/Classes/View/Slot/Service/SlotFlexFormService.php
@@ -168,6 +168,8 @@ XML;
         <config>
             {$slot->getFlexFormConfiguration()}
         </config>
+        
+        {$slot->getFlexFormAdditionalConfiguration()}  
     </TCEforms>
 </{$slot->getName()}>
 XML;

--- a/Classes/ViewHelpers/Slot/TextViewHelper.php
+++ b/Classes/ViewHelpers/Slot/TextViewHelper.php
@@ -22,13 +22,29 @@ use CuyZ\Notiz\View\Slot\Application\TextSlot;
 class TextViewHelper extends SlotViewHelper
 {
     /**
+     * @inheritdoc
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+
+        $this->registerArgument('rte', 'bool', 'Should rich text be enabled?', false, false);
+        $this->registerArgument('rteMode', 'string', 'Mode of the RTE: can be a CKEditor preset or a RteHtmlArea configuration.', false);
+    }
+
+    /**
      * @return Slot
      */
     protected function getSlot()
     {
+        $rte = $this->arguments['rte'];
+        $rteMode = $this->arguments['rteMode'];
+
         return new TextSlot(
             $this->getSlotName(),
-            $this->getSlotLabel()
+            $this->getSlotLabel(),
+            $rte,
+            $rteMode
         );
     }
 }

--- a/Documentation/Notifications/Email/Customize-email-body.md
+++ b/Documentation/Notifications/Email/Customize-email-body.md
@@ -92,7 +92,8 @@ The following variables can be accessed within this section:
 --------------------------------------------------------------------------------
 <f:section name="Slots">
     <nz:slot.text name="FirstPart"
-                  label="First part" />
+                  label="First part"
+                  rte="true" />
 
     <nz:slot.input name="SingleFeed"
                    label="Feed" />
@@ -108,7 +109,9 @@ been processed with the marker replacement.
 You can access every marker defined by the event directly as Fluid variables.
 --------------------------------------------------------------------------------
 <f:section name="Body">
-    <nz:slot.render name="FirstPart" />
+    <f:format.html>
+        <nz:slot.render name="FirstPart" />
+    </f:format.html>
 
     <ul>
         <f:for each="{feeds}" as="feed">

--- a/Resources/Private/Language/Notification/Entity/Fields.xlf
+++ b/Resources/Private/Language/Notification/Entity/Fields.xlf
@@ -22,6 +22,10 @@
             <trans-unit id="field.markers.description">
                 <source>These markers are provided by the event “%s”.</source>
             </trans-unit>
+
+            <trans-unit id="field.rte.ck_editor_preset_missing">
+                <source>Warning: the CKEditor preset “%s” has not been registered. You can register it by adding an entry to `$GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets']`.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Language/Notification/Entity/fr.Fields.xlf
+++ b/Resources/Private/Language/Notification/Entity/fr.Fields.xlf
@@ -22,6 +22,10 @@
             <trans-unit id="field.markers.description">
                 <target>Ces marqueurs sont fournis par l'événement « %s ».</target>
             </trans-unit>
+
+            <trans-unit id="field.rte.ck_editor_preset_missing">
+                <target>Attention : le préréglage « %s » pour CKEditor n'a pas été configuré. Vous pouvez l'enregistrer en ajoutant une entrée dans `$GLOBALS['TYPO3_CONF_VARS']['RTE']['Presets']`.</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/Private/Templates/Mail/Default.html
+++ b/Resources/Private/Templates/Mail/Default.html
@@ -13,7 +13,8 @@ The following variables can be accessed within this section:
 --------------------------------------------------------------------------------
 <f:section name="Slots">
     <nz:slot.text name="Default"
-                      label="LLL:EXT:notiz/Resources/Private/Language/Notification/Email/Entity:field.body.slot.default" />
+                  label="LLL:EXT:notiz/Resources/Private/Language/Notification/Email/Entity:field.body.slot.default"
+                  rte="true" />
 </f:section>
 
 --------------------------------------------------------------------------------
@@ -22,5 +23,7 @@ actual body of the template: the slots defined in the section above will be
 rendered here, after they have been processed with the marker replacement.
 --------------------------------------------------------------------------------
 <f:section name="Body">
-    <nz:slot.render name="Default" />
+    <f:format.html>
+        <nz:slot.render name="Default" />
+    </f:format.html>
 </f:section>


### PR DESCRIPTION
Text slots can now use RTE mode like this:

```html
<nz:slot.text name="MySlot"
              label="My slot"
              rte="true"
              rteMode="my-ckeditor-preset" />
```

You can use your own CKEditor preset by filling the argument `rteMode`.

Don't forget to wrap the rendering of your slot like this:

```html
<f:format.html>
    <nz:slot.render name="MySlot" />
</f:format.html>
```

A legacy mode is also introduced, allowing old configuration from
EXT:rtehtmlarea to work as well in the `rteMode` argument.