### PR TITLE
[BUGFIX] Render non-existing markers as an empty string

### DIFF
--- a/Classes/Core/Property/Service/MarkerParser.php
+++ b/Classes/Core/Property/Service/MarkerParser.php
@@ -49,9 +49,14 @@ class MarkerParser implements SingletonInterface
         foreach ($variables as $index => $variable) {
             $identifier = $identifiers[$index];
             $root = $roots[$index];
-            $marker = $markers[$root];
 
-            $value = $this->getVariableValue($variable, $root, $marker);
+            if (!isset($markers[$root])) {
+                $value = '';
+            } else {
+                $marker = $markers[$root];
+
+                $value = $this->getVariableValue($variable, $root, $marker);
+            }
 
             $replacePairs[$identifier] = $value;
         }

--- a/Classes/Core/Property/Service/MarkerParser.php
+++ b/Classes/Core/Property/Service/MarkerParser.php
@@ -53,12 +53,12 @@ class MarkerParser implements SingletonInterface
             if (!isset($markers[$root])) {
                 $value = '';
             } else {
-                $marker = $markers[$root];
-
-                $value = $this->getVariableValue($variable, $root, $marker);
+                $value = $this->getVariableValue($variable, $root, $markers[$root]);
             }
 
-            $replacePairs[$identifier] = $value;
+            $replacePairs[$identifier] = isset($markers[$root])
+                ? $this->getVariableValue($variable, $root, $markers[$root])
+                : '';
         }
 
         return strtr($string, $replacePairs);

--- a/Classes/Core/Property/Service/MarkerParser.php
+++ b/Classes/Core/Property/Service/MarkerParser.php
@@ -50,12 +50,6 @@ class MarkerParser implements SingletonInterface
             $identifier = $identifiers[$index];
             $root = $roots[$index];
 
-            if (!isset($markers[$root])) {
-                $value = '';
-            } else {
-                $value = $this->getVariableValue($variable, $root, $markers[$root]);
-            }
-
             $replacePairs[$identifier] = isset($markers[$root])
                 ? $this->getVariableValue($variable, $root, $markers[$root])
                 : '';


### PR DESCRIPTION
When a notification content (like an email slot) contains a non-existing marker, the parser will throw a fatal error.

With this patch, the parser will return an empty string.