### PR TITLE
[FEATURE] Allow event objects to give arbitrary data to notifications

### DIFF
--- a/Classes/Core/Event/Support/HasNotificationData.php
+++ b/Classes/Core/Event/Support/HasNotificationData.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Core\Event\Support;
+
+/**
+ * This interface can be implemented by an object given to an event, when it
+ * needs to transfer arbitrary data to a notification during dispatching.
+ *
+ * For instance, you can implement this interface in a custom scheduler task:
+ *
+ * ```
+ * class MyCustomTask extends AbstractTask implements HasNotificationData
+ * {
+ *     protected $notificationData = [];
+ *
+ *     public function execute()
+ *     {
+ *         // Do things…
+ *
+ *         $this->notificationData['foo'] = 'bar';
+ *
+ *         // Do more things…
+ *
+ *         return true;
+ *     }
+ *
+ *     public function getNotificationData()
+ *     {
+ *         return $this->notificationData;
+ *     }
+ * }
+ * ```
+ *
+ * You can then use the marker `{data}` in your notification:
+ *
+ * `The task has been executed with "{data.foo}".`
+ *
+ * @see \CuyZ\Notiz\Domain\Event\Scheduler\SchedulerTaskEvent::fillTaskData
+ */
+interface HasNotificationData
+{
+    /**
+     * Returns an array containing arbitrary data that can be used within the
+     * markers of a notification.
+     *
+     * @return array
+     */
+    public function getNotificationData();
+}

--- a/Classes/Domain/Event/Scheduler/SchedulerTaskEvent.php
+++ b/Classes/Domain/Event/Scheduler/SchedulerTaskEvent.php
@@ -17,6 +17,7 @@
 namespace CuyZ\Notiz\Domain\Event\Scheduler;
 
 use CuyZ\Notiz\Core\Event\AbstractEvent;
+use CuyZ\Notiz\Core\Event\Support\HasNotificationData;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Scheduler\Task\AbstractTask;
 
@@ -44,6 +45,14 @@ abstract class SchedulerTaskEvent extends AbstractEvent
     protected $description;
 
     /**
+     * @marker
+     * @label Event/Scheduler/SchedulerTask:marker.data
+     *
+     * @var array
+     */
+    protected $data;
+
+    /**
      * @param AbstractTask $task
      */
     protected function checkTaskFilter(AbstractTask $task)
@@ -65,5 +74,9 @@ abstract class SchedulerTaskEvent extends AbstractEvent
         $this->uid = $task->getTaskUid();
         $this->title = $task->getTaskTitle();
         $this->description = $task->getDescription();
+
+        if ($task instanceof HasNotificationData) {
+            $this->data = $task->getNotificationData();
+        }
     }
 }

--- a/Resources/Private/Language/Event/Scheduler/SchedulerTask.xlf
+++ b/Resources/Private/Language/Event/Scheduler/SchedulerTask.xlf
@@ -19,6 +19,10 @@
                 <source>Invalid task</source>
             </trans-unit>
 
+            <trans-unit id="marker.data">
+                <source>Arbitrary data that can be filled by the task and used as markers.</source>
+            </trans-unit>
+
             <!--#########################-->
             <!--### EXECUTION FAILED  ###-->
             <!--#########################-->

--- a/Resources/Private/Language/Event/Scheduler/fr.SchedulerTask.xlf
+++ b/Resources/Private/Language/Event/Scheduler/fr.SchedulerTask.xlf
@@ -19,6 +19,10 @@
                 <target>Tâche invalide</target>
             </trans-unit>
 
+            <trans-unit id="marker.data">
+                <target>Données arbitraires qui peuvent être remplies par la tâche et utilisées dans les marqueurs.</target>
+            </trans-unit>
+
             <!--#########################-->
             <!--### EXECUTION FAILED  ###-->
             <!--#########################-->


### PR DESCRIPTION
A new interface `HasNotificationData` is introduced can be implemented
by an object given to an event, when it needs to transfer arbitrary data
to a notification during dispatching.

For instance, you can implement this interface in a custom scheduler
task:

```php
class MyCustomTask extends AbstractTask implements HasNotificationData
{
    protected $notificationData = [];

    public function execute()
    {
        // Do things…

        $this->notificationData['foo'] = 'bar';

        // Do more things…

        return true;
    }

    public function getNotificationData()
    {
        return $this->notificationData;
    }
}
```

You can then use the marker `{data}` in your notification:

`The task has been executed with "{data.foo}".`