### PR TITLE
[FEATURE] Introduce a signal dispatched before an email is sent

### DIFF
--- a/Documentation/Notifications/Email/README.md
+++ b/Documentation/Notifications/Email/README.md
@@ -38,7 +38,7 @@ Depending on the selected event, you have access to markers with dynamic values.
 These markers can be used in both the subject and the body.
 
 The body may be customized for complex emails. See the chapter 
-“[Customize email body][customize-email-body]” for more information.
+“[Customize email][customize-email]” for more information.
 
 ![Configuration tab][tab-configuration]
 
@@ -79,7 +79,7 @@ You can also override it by notification.
 
 [:books: Documentation index](../../README.md)
 
-[customize-email-body]: Customize-email-body.md
+[customize-email]: Customize-email.md
 
 [tab-general]: /Documentation/Images/EmailNotification/email-general.png
 [tab-event]: /Documentation/Images/EmailNotification/email-event.png

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -19,7 +19,7 @@ You can find below documentation on how to use and extend NotiZ.
     - [Example video](Example/Video.md)
 - [Notifications](Notifications/README.md)
     - [Email notification](Notifications/Email/README.md)
-        - [Customize email body](Notifications/Email/Customize-email-body.md)
+        - [Customize email body](Notifications/Email/Customize-email.md)
     - [Log notification](Notifications/Log-notification.md)
 - [Events](Events/README.md)
     - [Create a custom event](Events/Create-a-custom-event.md)


### PR DESCRIPTION
If you need to do advanced modification on your mail, you can use a PHP
signal. Register the slot in your `ext_localconf.php` file :

```php
<?php
// my_extension/ext_localconf.php

$dispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
    \TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class
);

$dispatcher->connect(
    \CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder::class,
    \CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder::COMPONENTS_SIGNAL,
    \Vendor\MyExtension\Service\Mail\MailTransformer::class,
    'registerDefinitionComponents'
);
```

Then modify your mail object as you need:

```php
<?php
// my_extension/Classes/Service/Mail/MailTransformer.php

namespace Vendor\MyExtension\Service\Mail;

use CuyZ\Notiz\Core\Channel\Payload;
use TYPO3\CMS\Core\Mail\MailMessage;
use TYPO3\CMS\Core\SingletonInterface;
use TYPO3\CMS\Core\Utility\GeneralUtility;

class MailTransformer implements SingletonInterface
{
    /**
     * @param MailMessage $mailMessage
     * @param Payload $payload
     */
    public function transform(MailMessage $mailMessage, Payload $payload)
    {
        $applicationContext = GeneralUtility::getApplicationContext();

        // We don't change anything in production.
        if ($applicationContext->isProduction()) {
            return;
        }

        // Add a prefix to the mail subject, containing the application context.
        $subject = "[$applicationContext][NotiZ] " . $mailMessage->getSubject();
        $mailMessage->setSubject($subject);

        // When not in production, we want the mail to be sent only to us.
        $mailMessage->setTo('webmaster@acme.com');
        $mailMessage->setCc([]);
        $mailMessage->setBcc([]);
    }
}
```