### PR TITLE
[FEATURE] Introduce `PropertyDefinitionBuilder` interface

### DIFF
--- a/Classes/Core/Exception/InvalidClassException.php
+++ b/Classes/Core/Exception/InvalidClassException.php
@@ -25,6 +25,7 @@ use CuyZ\Notiz\Core\Notification\Notification;
 use CuyZ\Notiz\Core\Notification\Processor\NotificationProcessor;
 use CuyZ\Notiz\Core\Notification\Settings\NotificationSettings;
 use CuyZ\Notiz\Core\Property\PropertyEntry;
+use CuyZ\Notiz\Core\Property\Support\PropertyBuilder;
 
 class InvalidClassException extends NotizException
 {
@@ -45,6 +46,8 @@ class InvalidClassException extends NotizException
     const EVENT_CONFIGURATION_FLEX_FORM_PROVIDER_MISSING_INTERFACE = 'The FlexForm provider class `%s` must implement the interface `%s`.';
 
     const CHANNEL_SETTINGS_MISSING_INTERFACE = 'The channel settings class `%s` must implement the interface `%s`.';
+
+    const EVENT_PROPERTY_BUILDER_MISSING_INTERFACE = 'The property builder `%s` must implement the interface `%s`.';
 
     /**
      * @param string $className
@@ -162,6 +165,19 @@ class InvalidClassException extends NotizException
             self::CHANNEL_SETTINGS_MISSING_INTERFACE,
             1507409177,
             [$className, ChannelSettings::class]
+        );
+    }
+
+    /**
+     * @param string $className
+     * @return static
+     */
+    public static function eventPropertyBuilderMissingInterface($className)
+    {
+        return self::makeNewInstance(
+            self::EVENT_PROPERTY_BUILDER_MISSING_INTERFACE,
+            1519756764,
+            [$className, PropertyBuilder::class]
         );
     }
 }

--- a/Classes/Core/Property/Support/PropertyBuilder.php
+++ b/Classes/Core/Property/Support/PropertyBuilder.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Core\Property\Support;
+
+use CuyZ\Notiz\Core\Notification\Notification;
+use CuyZ\Notiz\Core\Property\Factory\PropertyDefinition;
+
+/**
+ * This interface must be implemented by classes intended to build property
+ * definitions for a given event.
+ *
+ * To create a new builder, you need to have a class with the same name as your
+ * event at which you append `PropertyBuilder`. The method `build` of your
+ * builder will then be automatically called when needed.
+ *
+ * Example:
+ *
+ * `MyVendor\MyExtension\Domain\Event\MyEvent` -> Event
+ * `MyVendor\MyExtension\Domain\Event\MyEventPropertyBuilder` -> Builder
+ */
+interface PropertyBuilder
+{
+    const BUILDER_SUFFIX = 'PropertyBuilder';
+
+    /**
+     * @param PropertyDefinition $definition
+     * @param Notification $notification
+     * @return void
+     */
+    public function build(PropertyDefinition $definition, Notification $notification);
+}


### PR DESCRIPTION
This interface must be implemented by classes intended to build property
definitions for a given event.

To create a new builder, you need to have a class with the same name as
your event at which you append `PropertyBuilder`. The method `build` of
your builder will then be automatically called when needed.

Example:

`MyVendor\MyExtension\Domain\Event\MyEvent` -> Event
`MyVendor\MyExtension\Domain\Event\MyEventPropertyBuilder` -> Builder