### PR TITLE
[FEATURE] Introduce event for submission of forms from core extension

### DIFF
--- a/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
+++ b/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
@@ -23,6 +23,7 @@ use CuyZ\Notiz\Domain\Definition\Builder\Component\Source\TypoScriptDefinitionSo
 use CuyZ\Notiz\Service\ExtensionConfigurationService;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 
 /**
  * Service used for registration of default definition components supplied by
@@ -84,7 +85,9 @@ class DefaultDefinitionComponents implements SingletonInterface
         }
 
         // The core extension "form" can dispatch events.
-        if (ExtensionManagementUtility::isLoaded('form')) {
+        if (ExtensionManagementUtility::isLoaded('form')
+            && version_compare(VersionNumberUtility::getCurrentTypo3Version(), '8.0.0', '>=')
+        ) {
             $typoScriptDefinitionSource->addTypoScriptFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Form.typoscript');
         }
     }

--- a/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
+++ b/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
@@ -82,5 +82,10 @@ class DefaultDefinitionComponents implements SingletonInterface
                 $typoScriptDefinitionSource->addTypoScriptFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Scheduler.typoscript');
             }
         }
+
+        // The core extension "form" can dispatch events.
+        if (ExtensionManagementUtility::isLoaded('form')) {
+            $typoScriptDefinitionSource->addTypoScriptFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Form.typoscript');
+        }
     }
 }

--- a/Classes/Domain/Event/Form/DispatchFormNotificationEvent.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationEvent.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Domain\Event\Form;
+
+use CuyZ\Notiz\Core\Event\AbstractEvent;
+use CuyZ\Notiz\Core\Property\Factory\PropertyContainer;
+use CuyZ\Notiz\Domain\Property\Email;
+use TYPO3\CMS\Extbase\Mvc\Controller\ControllerContext;
+use TYPO3\CMS\Form\Domain\Finishers\FinisherContext;
+use TYPO3\CMS\Form\Domain\Runtime\FormRuntime;
+use TYPO3\CMS\Form\Mvc\Persistence\FormPersistenceManagerInterface;
+
+/**
+ * This event is triggered when a form that implements the notification dispatch
+ * finisher is submitted.
+ *
+ * The identifier configured in the finisher must be the same as the identifier
+ * in this event options, or the event is canceled.
+ */
+class DispatchFormNotificationEvent extends AbstractEvent
+{
+    /**
+     * @label Event/Form/DispatchFormNotification:marker.form_values
+     * @marker
+     *
+     * @var array
+     */
+    protected $formValues;
+
+    /**
+     * @label Event/Form/DispatchFormNotification:marker.form_runtime
+     * @marker
+     *
+     * @var FormRuntime
+     */
+    protected $formRuntime;
+
+    /**
+     * @label Event/Form/DispatchFormNotification:marker.controller_context
+     * @marker
+     *
+     * @var ControllerContext
+     */
+    protected $controllerContext;
+
+    /**
+     * @var FormPersistenceManagerInterface
+     */
+    protected $formPersistenceManager;
+
+    /**
+     * @param FinisherContext $finisherContext
+     */
+    public function run(FinisherContext $finisherContext)
+    {
+        $identifier = $this->configuration['formDefinition'];
+        $this->formRuntime = $finisherContext->getFormRuntime();
+
+        if (!$identifier
+            || $this->formRuntime->getFormDefinition()->getPersistenceIdentifier() !== $identifier
+        ) {
+            $this->cancelDispatch();
+        }
+
+        $this->formValues = $finisherContext->getFormValues();
+        $this->controllerContext = $finisherContext->getControllerContext();
+    }
+
+    /**
+     * Adds the fields values to the email properties so they can be used as
+     * recipients for email notifications.
+     *
+     * @param PropertyContainer $container
+     */
+    public function fillPropertyEntries(PropertyContainer $container)
+    {
+        parent::fillPropertyEntries($container);
+
+        if ($container->getPropertyType() !== Email::class) {
+            return;
+        }
+
+        foreach ($this->formValues as $key => $value) {
+            if ($container->hasEntry($key)) {
+                $container->getEntry($key)->setValue($value);
+            }
+        }
+    }
+
+    /**
+     * @param FormPersistenceManagerInterface $formPersistenceManager
+     */
+    public function injectFormPersistenceManager(FormPersistenceManagerInterface $formPersistenceManager)
+    {
+        $this->formPersistenceManager = $formPersistenceManager;
+    }
+}

--- a/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Domain\Event\Form;
+
+use CuyZ\Notiz\Core\Notification\Notification;
+use CuyZ\Notiz\Core\Property\Factory\PropertyDefinition;
+use CuyZ\Notiz\Core\Property\Support\PropertyBuilder;
+use CuyZ\Notiz\Domain\Property\Email;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
+use TYPO3\CMS\Form\Domain\Factory\ArrayFormFactory;
+use TYPO3\CMS\Form\Domain\Model\FormDefinition;
+use TYPO3\CMS\Form\Domain\Model\FormElements\FormElementInterface;
+use TYPO3\CMS\Form\Mvc\Persistence\FormPersistenceManagerInterface;
+
+class DispatchFormNotificationEventPropertyBuilder implements PropertyBuilder, SingletonInterface
+{
+    /**
+     * @var FormPersistenceManagerInterface
+     */
+    protected $formPersistenceManager;
+
+    /**
+     * @var ArrayFormFactory
+     */
+    protected $arrayFormFactory;
+
+    /**
+     * @param FormPersistenceManagerInterface $formPersistenceManager
+     * @param ArrayFormFactory $arrayFormFactory
+     */
+    public function __construct(FormPersistenceManagerInterface $formPersistenceManager, ArrayFormFactory $arrayFormFactory)
+    {
+        $this->formPersistenceManager = $formPersistenceManager;
+        $this->arrayFormFactory = $arrayFormFactory;
+    }
+
+    /**
+     * Will fetch all fields from the form definition and add them to the
+     * definition of the email properties.
+     *
+     * This will allow selecting fields that can contain an email address as a
+     * recipient for email notifications.
+     *
+     * @param PropertyDefinition $definition
+     * @param Notification $notification
+     * @return void
+     */
+    public function build(PropertyDefinition $definition, Notification $notification)
+    {
+        if ($definition->getPropertyType() !== Email::class) {
+            return;
+        }
+
+        $eventConfiguration = $notification->getEventConfiguration();
+
+        // @PHP7
+        $identifier = isset($eventConfiguration['formDefinition'])
+            ? $eventConfiguration['formDefinition']
+            : null;
+
+        if (!$identifier) {
+            return;
+        }
+
+        if (!$this->formPersistenceManager->exists($identifier)) {
+            return;
+        }
+
+        $formDefinition = $this->getFormDefinition($identifier);
+
+        /*
+         * Unfortunately there is no getter method to fetch all elements from a
+         * form definition, so we use this little hack to get them.
+         */
+        $elements = ObjectAccess::getProperty($formDefinition, 'elementsByIdentifier', true);
+
+        foreach ($elements as $key => $element) {
+            /** @var FormElementInterface $element */
+            $definition->addEntry($element->getIdentifier())
+                ->setLabel($element->getLabel() . ' (' . $element->getIdentifier() . ')');
+        }
+    }
+
+    /**
+     * @param string $identifier
+     * @return FormDefinition
+     */
+    protected function getFormDefinition($identifier)
+    {
+        $formDefinitionArray = $this->formPersistenceManager->load($identifier);
+
+        return $this->arrayFormFactory->build($formDefinitionArray);
+    }
+}

--- a/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
@@ -89,7 +89,7 @@ class DispatchFormNotificationEventPropertyBuilder implements PropertyBuilder, S
          */
         $elements = ObjectAccess::getProperty($formDefinition, 'elementsByIdentifier', true);
 
-        foreach ($elements as $key => $element) {
+        foreach ($elements as $element) {
             /** @var FormElementInterface $element */
             $definition->addEntry($element->getIdentifier())
                 ->setLabel($element->getLabel() . ' (' . $element->getIdentifier() . ')');

--- a/Classes/Domain/Event/Form/DispatchFormNotificationFinisher.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationFinisher.php
@@ -21,7 +21,7 @@ use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
 
 class DispatchFormNotificationFinisher extends AbstractFinisher
 {
-    const NOTIFICATION_DISPATCH_SIGNAL = 'dispatchNotification';
+    const DISPATCH_NOTIFICATION = 'DispatchNotification';
 
     /**
      * @var Dispatcher
@@ -36,7 +36,7 @@ class DispatchFormNotificationFinisher extends AbstractFinisher
     {
         $this->slotDispatcher->dispatch(
             self::class,
-            self::NOTIFICATION_DISPATCH_SIGNAL,
+            self::DISPATCH_NOTIFICATION,
             [$this->finisherContext]
         );
     }

--- a/Classes/Domain/Event/Form/DispatchFormNotificationFinisher.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationFinisher.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Domain\Event\Form;
+
+use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
+use TYPO3\CMS\Form\Domain\Finishers\AbstractFinisher;
+
+class DispatchFormNotificationFinisher extends AbstractFinisher
+{
+    const NOTIFICATION_DISPATCH_SIGNAL = 'dispatchNotification';
+
+    /**
+     * @var Dispatcher
+     */
+    protected $slotDispatcher;
+
+    /**
+     * This finisher dispatches a signal that will be caught by NotiZ and allow
+     * notifications to be sent.
+     */
+    protected function executeInternal()
+    {
+        $this->slotDispatcher->dispatch(
+            self::class,
+            self::NOTIFICATION_DISPATCH_SIGNAL,
+            [$this->finisherContext]
+        );
+    }
+
+    /**
+     * @param Dispatcher $slotDispatcher
+     */
+    public function injectSlotDispatcher(Dispatcher $slotDispatcher)
+    {
+        $this->slotDispatcher = $slotDispatcher;
+    }
+}

--- a/Classes/Domain/Event/Form/Service/ListFormNotifications.php
+++ b/Classes/Domain/Event/Form/Service/ListFormNotifications.php
@@ -16,6 +16,7 @@
 
 namespace CuyZ\Notiz\Domain\Event\Form\Service;
 
+use CuyZ\Notiz\Domain\Event\Form\DispatchFormNotificationFinisher;
 use CuyZ\Notiz\Service\Container;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Form\Mvc\Persistence\FormPersistenceManagerInterface;
@@ -49,7 +50,7 @@ class ListFormNotifications implements SingletonInterface
             $formDefinition = $this->formPersistenceManager->load($persistenceIdentifier);
 
             foreach ($formDefinition['finishers'] as $finisher) {
-                if ($finisher['identifier'] === 'DispatchNotification') {
+                if ($finisher['identifier'] === DispatchFormNotificationFinisher::DISPATCH_NOTIFICATION) {
                     $parameters['items'][] = [
                         $formDefinition['label'] . ' (' . $persistenceIdentifier . ')',
                         $persistenceIdentifier,

--- a/Classes/Domain/Event/Form/Service/ListFormNotifications.php
+++ b/Classes/Domain/Event/Form/Service/ListFormNotifications.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Domain\Event\Form\Service;
+
+use CuyZ\Notiz\Service\Container;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Form\Mvc\Persistence\FormPersistenceManagerInterface;
+
+class ListFormNotifications implements SingletonInterface
+{
+    /**
+     * @var FormPersistenceManagerInterface
+     */
+    protected $formPersistenceManager;
+
+    /**
+     * Manual dependency injection.
+     */
+    public function __construct()
+    {
+        $this->formPersistenceManager = Container::get(FormPersistenceManagerInterface::class);
+    }
+
+    /**
+     * Loops on every registered form definition and checks if it uses the
+     * notification dispatch finisher. If it does, the identifier is fetched and
+     * added to the list.
+     *
+     * @param array $parameters
+     */
+    public function doList(array &$parameters)
+    {
+        foreach ($this->formPersistenceManager->listForms() as $form) {
+            $persistenceIdentifier = $form['persistenceIdentifier'];
+            $formDefinition = $this->formPersistenceManager->load($persistenceIdentifier);
+
+            foreach ($formDefinition['finishers'] as $finisher) {
+                if ($finisher['identifier'] === 'DispatchNotification') {
+                    $parameters['items'][] = [
+                        $formDefinition['label'] . ' (' . $persistenceIdentifier . ')',
+                        $persistenceIdentifier,
+                    ];
+                }
+            }
+        }
+    }
+}

--- a/Configuration/FlexForm/Event/Form/DispatchFormNotificationEventFlexForm.xml
+++ b/Configuration/FlexForm/Event/Form/DispatchFormNotificationEventFlexForm.xml
@@ -1,0 +1,29 @@
+<T3DataStructure>
+    <meta>
+        <langDisable>1</langDisable>
+    </meta>
+    <sheets>
+        <sDEF>
+            <ROOT>
+                <TCEforms>
+                    <sheetTitle>Event : form notification dispatch</sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el>
+                    <formDefinition>
+                        <TCEforms>
+                            <label>LLL:EXT:notiz/Resources/Private/Language/Event/Form/DispatchFormNotification.xlf:flex_form.form_definition.label</label>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <itemsProcFunc>CuyZ\Notiz\Domain\Event\Form\Service\ListFormNotifications->doList</itemsProcFunc>
+                                <size>8</size>
+                                <eval>required</eval>
+                            </config>
+                        </TCEforms>
+                    </formDefinition>
+                </el>
+            </ROOT>
+        </sDEF>
+    </sheets>
+</T3DataStructure>

--- a/Configuration/TypoScript/Event/Events.Form.typoscript
+++ b/Configuration/TypoScript/Event/Events.Form.typoscript
@@ -1,0 +1,35 @@
+notiz {
+    eventGroups {
+        form {
+            label = Event/Form/FormEventGroup:title
+
+            events {
+                /*
+                * Dispatch form notification
+                * --------------------------
+                *
+                * This event is triggered when a form that implements the
+                * notification dispatch finisher is submitted.
+                */
+                dispatchFormNotification {
+                    label = Event/Form/DispatchFormNotification:title
+
+                    className = CuyZ\Notiz\Domain\Event\Form\DispatchFormNotificationEvent
+
+                    configuration {
+                        flexForm {
+                            file = EXT:notiz/Configuration/FlexForm/Event/Form/DispatchFormNotificationEventFlexForm.xml
+                        }
+                    }
+
+                    connection {
+                        type = signal
+
+                        className = CuyZ\Notiz\Domain\Event\Form\DispatchFormNotificationFinisher
+                        name = dispatchNotification
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Configuration/TypoScript/Event/Events.Form.typoscript
+++ b/Configuration/TypoScript/Event/Events.Form.typoscript
@@ -26,7 +26,7 @@ notiz {
                         type = signal
 
                         className = CuyZ\Notiz\Domain\Event\Form\DispatchFormNotificationFinisher
-                        name = dispatchNotification
+                        name = DispatchNotification
                     }
                 }
             }

--- a/Configuration/Yaml/Form/DispatchFormNotificationModule.yaml
+++ b/Configuration/Yaml/Form/DispatchFormNotificationModule.yaml
@@ -1,0 +1,27 @@
+TYPO3:
+  CMS:
+    Form:
+      prototypes:
+        standard:
+          formEditor:
+            translationFile:
+              10: 'EXT:form/Resources/Private/Language/Database.xlf'
+              20: 'EXT:notiz/Resources/Private/Language/Event/Form/DispatchFormNotification.xlf'
+          formElementsDefinition:
+            Form:
+              formEditor:
+                editors:
+                  900:
+                    selectOptions:
+                      1519552194:
+                        value: 'DispatchNotification'
+                        label: 'form_editor.finisher.dispatch_notification.label'
+                propertyCollections:
+                  finishers:
+                    1519552194:
+                      identifier: 'DispatchNotification'
+                      editors:
+                        __inheritances:
+                          10: 'TYPO3.CMS.Form.mixins.formElementMixins.BaseCollectionEditorsMixin'
+                        100:
+                          label: 'form_editor.finisher.dispatch_notification.label'

--- a/Configuration/Yaml/Form/DispatchFormNotificationPlugin.yaml
+++ b/Configuration/Yaml/Form/DispatchFormNotificationPlugin.yaml
@@ -1,0 +1,11 @@
+TYPO3:
+  CMS:
+    Form:
+      prototypes:
+        standard:
+          finishersDefinition:
+            DispatchNotification:
+              implementationClassName: CuyZ\Notiz\Domain\Event\Form\DispatchFormNotificationFinisher
+              formEditor:
+                iconIdentifier: 'tx-notiz-icon'
+                label: 'form_editor.finisher.dispatch_notification.label'

--- a/Resources/Private/Language/Event/Form/DispatchFormNotification.xlf
+++ b/Resources/Private/Language/Event/Form/DispatchFormNotification.xlf
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="en">
+        <header/>
+        <body>
+
+            <trans-unit id="title">
+                <source>A form was submitted</source>
+            </trans-unit>
+
+            <trans-unit id="flex_form.form_definition.label">
+                <source>Form definition</source>
+            </trans-unit>
+
+            <trans-unit id="marker.form_values">
+                <source>Form values submitted by the user.</source>
+            </trans-unit>
+            <trans-unit id="marker.form_runtime">
+                <source>Runtime object of the form, contains a lot of useful information.</source>
+            </trans-unit>
+            <trans-unit id="marker.controller_context">
+                <source>Current controller context that led to the submission of the form.</source>
+            </trans-unit>
+
+            <trans-unit id="form_editor.finisher.dispatch_notification.label">
+                <source>Dispatch a notification</source>
+            </trans-unit>
+
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/Event/Form/FormEventGroup.xlf
+++ b/Resources/Private/Language/Event/Form/FormEventGroup.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="en">
+        <header/>
+        <body>
+
+            <trans-unit id="title">
+                <source>Form</source>
+            </trans-unit>
+
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/Event/Form/fr.DispatchFormNotification.xlf
+++ b/Resources/Private/Language/Event/Form/fr.DispatchFormNotification.xlf
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="fr">
+        <header/>
+        <body>
+
+            <trans-unit id="title">
+                <target>Soumission d'un formulaire</target>
+            </trans-unit>
+
+            <trans-unit id="flex_form.form_definition.label">
+                <target>Définition du formulaire</target>
+            </trans-unit>
+
+            <trans-unit id="marker.form_values">
+                <target>Valeurs du formulaire soumises par l'utilisateur.</target>
+            </trans-unit>
+            <trans-unit id="marker.form_runtime">
+                <target>Objet courant du formulaire contenant de nombreuses informations.</target>
+            </trans-unit>
+            <trans-unit id="marker.controller_context">
+                <target>Contexte courant du contrôleur qui a permis la soumission du formulaire.</target>
+            </trans-unit>
+
+            <trans-unit id="form_editor.finisher.dispatch_notification.label">
+                <target>Envoyer une notification</target>
+            </trans-unit>
+
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/Event/Form/fr.FormEventGroup.xlf
+++ b/Resources/Private/Language/Event/Form/fr.FormEventGroup.xlf
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="fr">
+        <header/>
+        <body>
+
+            <trans-unit id="title">
+                <target>Formulaire</target>
+            </trans-unit>
+
+        </body>
+    </file>
+</xliff>

--- a/ext_typoscript_setup.txt
+++ b/ext_typoscript_setup.txt
@@ -11,3 +11,19 @@ config.tx_extbase.persistence.classes {
         }
     }
 }
+
+module.tx_form {
+    settings {
+        yamlConfigurations {
+            notizModule = EXT:notiz/Configuration/Yaml/Form/DispatchFormNotificationModule.yaml
+            notizPlugin = EXT:notiz/Configuration/Yaml/Form/DispatchFormNotificationPlugin.yaml
+        }
+    }
+}
+plugin.tx_form {
+    settings {
+        yamlConfigurations {
+            notizPlugin = EXT:notiz/Configuration/Yaml/Form/DispatchFormNotificationPlugin.yaml
+        }
+    }
+}


### PR DESCRIPTION
Adds a new finisher "Dispatch a notification" that can be added to a
form definition (accessible in the form editor backend module).

A new event "A form was submitted" is now accessible for notifications,
and provides several markers as well as email recipients based on
the submitted form values.