### PR TITLE
[FEATURE] Introduce signal dispatched when definition is built

### DIFF
--- a/Classes/Core/Definition/Builder/DefinitionBuilder.php
+++ b/Classes/Core/Definition/Builder/DefinitionBuilder.php
@@ -105,6 +105,7 @@ class DefinitionBuilder implements SingletonInterface
     use ExtendedSelfInstantiateTrait;
 
     const COMPONENTS_SIGNAL = 'manageDefinitionComponents';
+    const DEFINITION_BUILT_SIGNAL = 'definitionBuilt';
 
     /**
      * @var DefinitionComponents
@@ -173,6 +174,8 @@ class DefinitionBuilder implements SingletonInterface
                     }
                 }
             }
+
+            $this->sendDefinitionBuiltSignal();
         }
 
         return $this->definitionObject;
@@ -233,5 +236,22 @@ class DefinitionBuilder implements SingletonInterface
             self::COMPONENTS_SIGNAL,
             [$this->components]
         );
+    }
+
+    /**
+     * Sends a signal when the definition object is complete.
+     *
+     * Please be aware that this signal is sent only if no error was found when
+     * the definition was built.
+     */
+    protected function sendDefinitionBuiltSignal()
+    {
+        if (!$this->definitionObject->getValidationResult()->hasErrors()) {
+            $this->dispatcher->dispatch(
+                self::class,
+                self::DEFINITION_BUILT_SIGNAL,
+                [$this->definitionObject->getObject()]
+            );
+        }
     }
 }

--- a/Documentation/Markdown/Developers/Signals-connection.md
+++ b/Documentation/Markdown/Developers/Signals-connection.md
@@ -4,6 +4,56 @@
 
 See chapter [Customize the email object](../Notifications/Email/Customize-email.md#customize-the-email-object)
 
+## Definition was built
+
+You may need to use NotiZ definition to initialize things in your own extension.
+
+A signal will be dispatched when the definition object is complete, **only when 
+no error was found when it was built**.
+
+Note that you wont be able to modify the definition, only access its values.
+
+> *`my_extension/ext_localconf.php`*
+```php
+<?php
+$dispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+    \TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class
+);
+
+$dispatcher->connect(
+    \CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder::class,
+    \CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder::DEFINITION_BUILT_SIGNAL,
+    \Vendor\MyExtension\Plugin\MyPluginService::class,
+    'registerMyPlugin'
+);
+```
+
+> *`my_extension/Classes/Plugin/MyPluginService.php`*
+```php
+<?php
+
+namespace Vendor\MyExtension\Plugin;
+
+use CuyZ\Notiz\Core\Definition\Tree\Definition;
+use TYPO3\CMS\Core\SingletonInterface;
+
+class MyPluginService implements SingletonInterface
+{
+    /**
+     * Adds a custom plugin for every notification definition entry.
+     *
+     * @param Definition $definition
+     */
+    public function registerMyPlugin(Definition $definition)
+    {
+        foreach ($definition->getNotifications() as $notification) {
+            $this->addSomePluginForNotification($notification);
+        }
+    }
+}
+
+```
+
 ## Event was dispatched
 
 This signal is sent after an event was successfully dispatched with a 
@@ -22,7 +72,7 @@ $dispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 $dispatcher->connect(
     \CuyZ\Notiz\Core\Event\Runner\EventRunner::class,
     \CuyZ\Notiz\Core\Event\Runner\EventRunner::SIGNAL_EVENT_WAS_DISPATCHED,
-    \Vendor\MyExtension\Service\MessageService,
+    \Vendor\MyExtension\Service\MessageService::class,
     'eventWasDispatched'
 );
 ```
@@ -82,7 +132,7 @@ $dispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
 $dispatcher->connect(
     \CuyZ\Notiz\Core\Event\Runner\EventRunner::class,
     \CuyZ\Notiz\Core\Event\Runner\EventRunner::SIGNAL_EVENT_DISPATCH_ERROR,
-    \Vendor\MyExtension\Error\ErrorLogger,
+    \Vendor\MyExtension\Error\ErrorLogger::class,
     'logEventDispatchError'
 );
 ```


### PR DESCRIPTION
You may need to use NotiZ definition to initialize things in your own
extension.

A signal will be dispatched when the definition object is complete,
**only when no error was found when it was built**.

Note that you won't be able to modify the definition, only access its
values.

More information in the documentation.