### PR TITLE
[!!!][TASK] Separate properties handling from events

### DIFF
--- a/Classes/Core/Definition/Tree/EventGroup/Event/EventDefinition.php
+++ b/Classes/Core/Definition/Tree/EventGroup/Event/EventDefinition.php
@@ -21,8 +21,8 @@ use CuyZ\Notiz\Core\Definition\Tree\EventGroup\Event\Configuration\EventConfigur
 use CuyZ\Notiz\Core\Definition\Tree\EventGroup\Event\Connection\Connection;
 use CuyZ\Notiz\Core\Definition\Tree\EventGroup\EventGroup;
 use CuyZ\Notiz\Core\Notification\Notification;
+use CuyZ\Notiz\Core\Property\Factory\PropertyDefinition;
 use CuyZ\Notiz\Core\Property\Factory\PropertyFactory;
-use CuyZ\Notiz\Core\Property\PropertyEntry;
 use CuyZ\Notiz\Service\LocalizationService;
 use Romm\ConfigurationObject\Service\Items\DataPreProcessor\DataPreProcessor;
 use Romm\ConfigurationObject\Service\Items\DataPreProcessor\DataPreProcessorInterface;
@@ -140,11 +140,11 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
     /**
      * @param string $propertyClassName
      * @param Notification $notification
-     * @return PropertyEntry[]
+     * @return PropertyDefinition
      */
-    public function getPropertiesDefinition($propertyClassName, Notification $notification)
+    public function getPropertyDefinition($propertyClassName, Notification $notification)
     {
-        return PropertyFactory::get()->getPropertiesDefinition($propertyClassName, $this, $notification);
+        return PropertyFactory::get()->getPropertyDefinition($propertyClassName, $this, $notification);
     }
 
     /**

--- a/Classes/Core/Event/Event.php
+++ b/Classes/Core/Event/Event.php
@@ -18,16 +18,13 @@ namespace CuyZ\Notiz\Core\Event;
 
 use CuyZ\Notiz\Core\Definition\Tree\EventGroup\Event\EventDefinition;
 use CuyZ\Notiz\Core\Notification\Notification;
-use CuyZ\Notiz\Core\Property\Factory\PropertyContainer;
-use CuyZ\Notiz\Core\Property\Factory\PropertyDefinition;
-use CuyZ\Notiz\Core\Property\PropertyEntry;
 
 /**
  * Interface for an event that will be processed when a hook/signal is called.
  *
- * The purpose of an event is to process the data coming from the hook/signal to
- * fill properties. These properties are then used by the notifications bound to
- * this very event, to dispatch it with correct information.
+ * The purpose of an event is to process the data coming from the hook/signal.
+ * It may fill so-called "properties", that are then used by the notifications
+ * bound to this very event, to dispatch it with correct information.
  *
  * An example of an event usage could be:
  *
@@ -53,22 +50,11 @@ use CuyZ\Notiz\Core\Property\PropertyEntry;
  * #1 - Property definition
  * ------------------------
  *
- * An event must implement the method `buildPropertyDefinition()` that will be
- * called to build a full definition of a property type that can be processed by
- * the event.
+ * In order for an event to be able to fill properties, it has to
+ * implements the interface: @see \CuyZ\Notiz\Core\Event\Support\HasProperties
  *
- * The method is static, meaning that an event implementation should always know
- * in advance which data exactly can be handled during the event dispatch
- * process.
- *
- * The method will be called for every property type that can be asked by a
- * notification, so the code must be adapted to handle these several calls. See
- * the method documentation for more information:
- *
- * @see \CuyZ\Notiz\Core\Event\Event::buildPropertyDefinition
- *
- * In order to be sure that an event can be dispatched by all notifications you
- * need to cover every case for all registered property types.
+ * The static method `getPropertyBuilder` must return an instance of a property
+ * builder that will be used to fetch the definition for used properties.
  *
  * #2 - Dispatch process
  * ---------------------
@@ -90,88 +76,13 @@ use CuyZ\Notiz\Core\Property\PropertyEntry;
  * Now that the data was saved during phase #2, the notifications bound to this
  * event will want to access to this data.
  *
- * @see \CuyZ\Notiz\Core\Event\Event::fillPropertyEntries
+ * @see \CuyZ\Notiz\Core\Event\Support\HasProperties::fillPropertyEntries
  *
  * In this method, the properties that were added in the definitions during
  * phase #1 should be filled with correct values.
  */
 interface Event
 {
-    /**
-     * Builds a definition for a given property type that can be used by
-     * notifications.
-     *
-     * Be aware that this method can be called several times, depending on what
-     * type of property the notifications need.
-     *
-     * An example of implementation for this method can be:
-     *
-     * ```
-     * public static function buildPropertyDefinition(PropertyDefinition $definition)
-     * {
-     *     switch ($definition->getPropertyType()) {
-     *         case Marker::class:
-     *             $entry = $definition->addEntry('user_name');
-     *             $entry->setLabel('Registered user name');
-     *             break;
-     *         case Email::class:
-     *             $entry = $definition->addEntry('user_email');
-     *             $entry->setLabel('Registered user');
-     *             break;
-     *     }
-     * }
-     * ```
-     *
-     * @param PropertyDefinition $definition
-     * @param Notification $notification
-     * @return void
-     */
-    public static function buildPropertyDefinition(PropertyDefinition $definition, Notification $notification);
-
-    /**
-     * Method called to fill the values of the properties that were added during
-     * the definition phase, so they can be used by notifications.
-     *
-     * @see \CuyZ\Notiz\Core\Event\Event::buildPropertyDefinition
-     *
-     * The property container passed as a parameter contains the entries added
-     * in the definition: each one should be filled with a value that was
-     * fetched during the dispatch process of the event.
-     *
-     * Be aware that this method may be called multiple times, as a notification
-     * may need several property types.
-     *
-     * An example of implementation for this method can be:
-     *
-     * ```
-     * public function fillPropertyEntries(PropertyContainer $container)
-     * {
-     *     switch ($container->getPropertyType()) {
-     *         case Marker::class:
-     *             $container->getEntry('user_name')
-     *                 ->setValue($this->userName);
-     *             break;
-     *         case Email::class:
-     *             $container->getEntry('user_email')
-     *                 ->setValue($this->userEmail);
-     *             break;
-     *     }
-     * }
-     * ```
-     *
-     * @param PropertyContainer $container
-     * @return void
-     */
-    public function fillPropertyEntries(PropertyContainer $container);
-
-    /**
-     * Returns the property entries list for the given property type.
-     *
-     * @param string $propertyClassName
-     * @return PropertyEntry[]
-     */
-    public function getProperties($propertyClassName);
-
     /**
      * Must return the definition for this event instance.
      *

--- a/Classes/Core/Event/Support/HasProperties.php
+++ b/Classes/Core/Event/Support/HasProperties.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Core\Event\Support;
+
+use CuyZ\Notiz\Core\Property\Builder\PropertyBuilder;
+use CuyZ\Notiz\Core\Property\Factory\PropertyContainer;
+
+/**
+ * This interface can be implemented by an event if it can provide properties
+ * that can be used by other services (markers, email, etc.).
+ */
+interface HasProperties
+{
+    /**
+     * Must return an instance of a property builder that will be used to fetch
+     * the definition for properties of the event.
+     *
+     * @return PropertyBuilder
+     */
+    public static function getPropertyBuilder();
+
+    /**
+     * Method called to fill the values of the properties that were added during
+     * the definition phase, so they can be used by notifications.
+     *
+     * @see \CuyZ\Notiz\Core\Event\HasProperties::buildPropertyDefinition
+     *
+     * The property container passed as a parameter contains the entries added
+     * in the definition: each one should be filled with a value that was
+     * fetched during the dispatch process of the event.
+     *
+     * Be aware that this method may be called multiple times, as a notification
+     * may need several property types.
+     *
+     * An example of implementation for this method can be:
+     *
+     * ```
+     * public function fillPropertyEntries(PropertyContainer $container)
+     * {
+     *     switch ($container->getPropertyType()) {
+     *         case Marker::class:
+     *             $container->getEntry('user_name')
+     *                 ->setValue($this->userName);
+     *             break;
+     *         case Email::class:
+     *             $container->getEntry('user_email')
+     *                 ->setValue($this->userEmail);
+     *             break;
+     *     }
+     * }
+     * ```
+     *
+     * @param PropertyContainer $container
+     * @return void
+     */
+    public function fillPropertyEntries(PropertyContainer $container);
+}

--- a/Classes/Core/Exception/InvalidClassException.php
+++ b/Classes/Core/Exception/InvalidClassException.php
@@ -24,8 +24,8 @@ use CuyZ\Notiz\Core\Event\Event;
 use CuyZ\Notiz\Core\Notification\Notification;
 use CuyZ\Notiz\Core\Notification\Processor\NotificationProcessor;
 use CuyZ\Notiz\Core\Notification\Settings\NotificationSettings;
+use CuyZ\Notiz\Core\Property\Builder\PropertyBuilder;
 use CuyZ\Notiz\Core\Property\PropertyEntry;
-use CuyZ\Notiz\Core\Property\Support\PropertyBuilder;
 
 class InvalidClassException extends NotizException
 {

--- a/Classes/Core/Notification/Service/NotificationTcaService.php
+++ b/Classes/Core/Notification/Service/NotificationTcaService.php
@@ -194,7 +194,7 @@ abstract class NotificationTcaService implements SingletonInterface
         $notification = $this->getNotification($row);
 
         /** @var Marker[] $markers */
-        $markers = $eventDefinition->getPropertiesDefinition(Marker::class, $notification);
+        $markers = $eventDefinition->getPropertyDefinition(Marker::class, $notification)->getEntries();
 
         $output = '';
 

--- a/Classes/Core/Property/Builder/PropertyBuilder.php
+++ b/Classes/Core/Property/Builder/PropertyBuilder.php
@@ -14,7 +14,7 @@
  * http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace CuyZ\Notiz\Core\Property\Support;
+namespace CuyZ\Notiz\Core\Property\Builder;
 
 use CuyZ\Notiz\Core\Notification\Notification;
 use CuyZ\Notiz\Core\Property\Factory\PropertyDefinition;

--- a/Classes/Core/Property/Factory/PropertyDefinition.php
+++ b/Classes/Core/Property/Factory/PropertyDefinition.php
@@ -34,7 +34,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * A property definition is built by an event, because the event is the only one
  * to know which entries can be added.
  *
- * @see \CuyZ\Notiz\Core\Event\Event::buildPropertyDefinition
+ * @see \CuyZ\Notiz\Core\Event\Support\HasProperties::buildPropertyDefinition
  *
  * In the method above, the definition can be manipulated to add new entries:
  *

--- a/Classes/Core/Property/Factory/PropertyFactory.php
+++ b/Classes/Core/Property/Factory/PropertyFactory.php
@@ -20,6 +20,7 @@ use CuyZ\Notiz\Core\Definition\Tree\EventGroup\Event\EventDefinition;
 use CuyZ\Notiz\Core\Event\Event;
 use CuyZ\Notiz\Core\Event\Support\HasProperties;
 use CuyZ\Notiz\Core\Notification\Notification;
+use CuyZ\Notiz\Core\Property\PropertyEntry;
 use CuyZ\Notiz\Service\Traits\ExtendedSelfInstantiateTrait;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -93,8 +94,8 @@ class PropertyFactory implements SingletonInterface
     }
 
     /**
-     * Returns a list of property entries that have been processed by the given
-     * event. This means all their data can be accessed properly.
+     * Returns a container of property entries that have been processed by the
+     * given event. This means all their data can be accessed properly.
      *
      * Note that each property type for each event is processed only once,
      * memoization is used to serve the same properties later in a same run
@@ -104,7 +105,7 @@ class PropertyFactory implements SingletonInterface
      * @param Event $event
      * @return PropertyContainer
      */
-    public function getProperties($propertyClassName, Event $event)
+    public function getPropertyContainer($propertyClassName, Event $event)
     {
         $propertyClassName = $this->objectContainer->getImplementationClassName($propertyClassName);
 
@@ -115,6 +116,17 @@ class PropertyFactory implements SingletonInterface
         }
 
         return $this->properties[$hash];
+    }
+
+
+    /**
+     * @param string $propertyClassName
+     * @param Event $event
+     * @return PropertyEntry[]
+     */
+    public function getProperties($propertyClassName, Event $event)
+    {
+        return $this->getPropertyContainer($propertyClassName, $event)->getEntries();
     }
 
     /**

--- a/Classes/Core/Property/PropertyEntry.php
+++ b/Classes/Core/Property/PropertyEntry.php
@@ -22,7 +22,7 @@ use CuyZ\Notiz\Service\LocalizationService;
 /**
  * An entry of a property definition, that is created in an event:
  *
- * @see \CuyZ\Notiz\Core\Event\Event::buildPropertyDefinition
+ * @see \CuyZ\Notiz\Core\Event\Support\HasProperties::buildPropertyDefinition
  *
  * An entry must be named, and can contain a label. You may add more class
  * properties with own getters/setters, that can be filled during the definition
@@ -32,7 +32,7 @@ use CuyZ\Notiz\Service\LocalizationService;
  * notification, but you wont be able to force a value after the method below
  * was called:
  *
- * @see \CuyZ\Notiz\Core\Event\Event::fillPropertyEntries
+ * @see \CuyZ\Notiz\Core\Event\Support\HasProperties::fillPropertyEntries
  */
 abstract class PropertyEntry
 {

--- a/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
@@ -17,8 +17,9 @@
 namespace CuyZ\Notiz\Domain\Event\Form;
 
 use CuyZ\Notiz\Core\Notification\Notification;
+use CuyZ\Notiz\Core\Property\Builder\PropertyBuilder;
 use CuyZ\Notiz\Core\Property\Factory\PropertyDefinition;
-use CuyZ\Notiz\Core\Property\Support\PropertyBuilder;
+use CuyZ\Notiz\Core\Property\Service\TagsPropertyService;
 use CuyZ\Notiz\Domain\Property\Email;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Extbase\Reflection\ObjectAccess;
@@ -30,6 +31,11 @@ use TYPO3\CMS\Form\Mvc\Persistence\FormPersistenceManagerInterface;
 class DispatchFormNotificationEventPropertyBuilder implements PropertyBuilder, SingletonInterface
 {
     /**
+     * @var TagsPropertyService
+     */
+    protected $tagsPropertyService;
+
+    /**
      * @var FormPersistenceManagerInterface
      */
     protected $formPersistenceManager;
@@ -40,11 +46,16 @@ class DispatchFormNotificationEventPropertyBuilder implements PropertyBuilder, S
     protected $arrayFormFactory;
 
     /**
+     * @param TagsPropertyService $tagsPropertyService
      * @param FormPersistenceManagerInterface $formPersistenceManager
      * @param ArrayFormFactory $arrayFormFactory
      */
-    public function __construct(FormPersistenceManagerInterface $formPersistenceManager, ArrayFormFactory $arrayFormFactory)
-    {
+    public function __construct(
+        TagsPropertyService $tagsPropertyService,
+        FormPersistenceManagerInterface $formPersistenceManager,
+        ArrayFormFactory $arrayFormFactory
+    ) {
+        $this->tagsPropertyService = $tagsPropertyService;
         $this->formPersistenceManager = $formPersistenceManager;
         $this->arrayFormFactory = $arrayFormFactory;
     }
@@ -63,6 +74,8 @@ class DispatchFormNotificationEventPropertyBuilder implements PropertyBuilder, S
     public function build(PropertyDefinition $definition, Notification $notification)
     {
         if ($definition->getPropertyType() !== Email::class) {
+            $this->tagsPropertyService->fillPropertyDefinition($definition);
+
             return;
         }
 

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailAddressMapper.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailAddressMapper.php
@@ -17,6 +17,7 @@
 namespace CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\Service;
 
 use CuyZ\Notiz\Core\Channel\Payload;
+use CuyZ\Notiz\Core\Property\Factory\PropertyFactory;
 use CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\EntityEmailNotification;
 use CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\Settings\EntityEmailSettings;
 use CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\Settings\GlobalRecipients\Recipient;
@@ -47,13 +48,14 @@ class EntityEmailAddressMapper
 
     /**
      * @param Payload $payload
+     * @param PropertyFactory $propertyFactory
      */
-    public function __construct(Payload $payload)
+    public function __construct(Payload $payload, PropertyFactory $propertyFactory)
     {
         $this->notification = $payload->getNotification();
         $this->notificationSettings = $payload->getNotificationDefinition()->getSettings();
 
-        $this->eventRecipients = $payload->getEvent()->getProperties(Email::class);
+        $this->eventRecipients = $propertyFactory->getProperties(Email::class, $payload->getEvent())->getEntries();
         $this->globalRecipients = $this->notificationSettings->getGlobalRecipients()->getRecipients();
     }
 

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailAddressMapper.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailAddressMapper.php
@@ -55,7 +55,7 @@ class EntityEmailAddressMapper
         $this->notification = $payload->getNotification();
         $this->notificationSettings = $payload->getNotificationDefinition()->getSettings();
 
-        $this->eventRecipients = $propertyFactory->getProperties(Email::class, $payload->getEvent())->getEntries();
+        $this->eventRecipients = $propertyFactory->getProperties(Email::class, $payload->getEvent());
         $this->globalRecipients = $this->notificationSettings->getGlobalRecipients()->getRecipients();
     }
 

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailTemplateBuilder.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailTemplateBuilder.php
@@ -18,6 +18,7 @@ namespace CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\Service;
 
 use CuyZ\Notiz\Core\Channel\Payload;
 use CuyZ\Notiz\Core\Event\Event;
+use CuyZ\Notiz\Core\Property\Factory\PropertyFactory;
 use CuyZ\Notiz\Core\Property\Service\MarkerParser;
 use CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\EntityEmailNotification;
 use CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\Settings\EntityEmailSettings;
@@ -60,8 +61,9 @@ class EntityEmailTemplateBuilder
      * @param Payload $payload
      * @param MarkerParser $markerParser
      * @param SlotViewService $slotViewService
+     * @param PropertyFactory $propertyFactory
      */
-    public function __construct(Payload $payload, MarkerParser $markerParser, SlotViewService $slotViewService)
+    public function __construct(Payload $payload, MarkerParser $markerParser, SlotViewService $slotViewService, PropertyFactory $propertyFactory)
     {
         $this->notification = $payload->getNotification();
         $this->notificationSettings = $payload->getNotificationDefinition()->getSettings();
@@ -69,7 +71,7 @@ class EntityEmailTemplateBuilder
         $this->event = $payload->getEvent();
 
         $this->markerParser = $markerParser;
-        $this->markers = $payload->getEvent()->getProperties(Marker::class);
+        $this->markers = $propertyFactory->getProperties(Marker::class, $payload->getEvent())->getEntries();
 
         $this->slotViewService = $slotViewService;
     }

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailTemplateBuilder.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailTemplateBuilder.php
@@ -71,7 +71,7 @@ class EntityEmailTemplateBuilder
         $this->event = $payload->getEvent();
 
         $this->markerParser = $markerParser;
-        $this->markers = $propertyFactory->getProperties(Marker::class, $payload->getEvent())->getEntries();
+        $this->markers = $propertyFactory->getProperties(Marker::class, $payload->getEvent());
 
         $this->slotViewService = $slotViewService;
     }

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaService.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaService.php
@@ -73,7 +73,7 @@ class EntityEmailTcaService extends NotificationTcaService
                     'value' => $recipient->getName(),
                 ];
             },
-            $eventDefinition->getPropertiesDefinition(Email::class, $notification)
+            $eventDefinition->getPropertyDefinition(Email::class, $notification)->getEntries()
         );
 
         $globalRecipients = array_map(
@@ -197,7 +197,7 @@ class EntityEmailTcaService extends NotificationTcaService
         $notification = $this->getNotification($row);
 
         /** @var Email[] $recipients */
-        $recipients = $eventDefinition->getPropertiesDefinition(Email::class, $notification);
+        $recipients = $eventDefinition->getPropertyDefinition(Email::class, $notification)->getEntries();
 
         $globalRecipients = $this->getNotificationSettings()
             ->getGlobalRecipients()

--- a/Classes/Domain/Notification/Log/Application/EntityLog/Service/EntityLogMessageBuilder.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/Service/EntityLogMessageBuilder.php
@@ -49,7 +49,7 @@ class EntityLogMessageBuilder
         $this->notification = $payload->getNotification();
         $this->markerParser = $markerParser;
 
-        $this->markers = $propertyFactory->getProperties(Marker::class, $payload->getEvent())->getEntries();
+        $this->markers = $propertyFactory->getProperties(Marker::class, $payload->getEvent());
     }
 
     /**

--- a/Classes/Domain/Notification/Log/Application/EntityLog/Service/EntityLogMessageBuilder.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/Service/EntityLogMessageBuilder.php
@@ -17,6 +17,7 @@
 namespace CuyZ\Notiz\Domain\Notification\Log\Application\EntityLog\Service;
 
 use CuyZ\Notiz\Core\Channel\Payload;
+use CuyZ\Notiz\Core\Property\Factory\PropertyFactory;
 use CuyZ\Notiz\Core\Property\Service\MarkerParser;
 use CuyZ\Notiz\Domain\Notification\Log\LogNotification;
 use CuyZ\Notiz\Domain\Property\Marker;
@@ -41,13 +42,14 @@ class EntityLogMessageBuilder
     /**
      * @param Payload $payload
      * @param MarkerParser $markerParser
+     * @param PropertyFactory $propertyFactory
      */
-    public function __construct(Payload $payload, MarkerParser $markerParser)
+    public function __construct(Payload $payload, MarkerParser $markerParser, PropertyFactory $propertyFactory)
     {
         $this->notification = $payload->getNotification();
         $this->markerParser = $markerParser;
 
-        $this->markers = $payload->getEvent()->getProperties(Marker::class);
+        $this->markers = $propertyFactory->getProperties(Marker::class, $payload->getEvent())->getEntries();
     }
 
     /**

--- a/Classes/Domain/Property/Builder/TagsPropertyBuilder.php
+++ b/Classes/Domain/Property/Builder/TagsPropertyBuilder.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Domain\Property\Builder;
+
+use CuyZ\Notiz\Core\Notification\Notification;
+use CuyZ\Notiz\Core\Property\Builder\PropertyBuilder;
+use CuyZ\Notiz\Core\Property\Factory\PropertyDefinition;
+use CuyZ\Notiz\Core\Property\Service\TagsPropertyService;
+use TYPO3\CMS\Core\SingletonInterface;
+
+/**
+ * Provided property builder that will fetch the properties using an event class
+ * attributes and their annotations.
+ *
+ * @see \CuyZ\Notiz\Core\Property\Service\TagsPropertyService
+ */
+class TagsPropertyBuilder implements PropertyBuilder, SingletonInterface
+{
+    /**
+     * @var TagsPropertyService
+     */
+    protected $tagsPropertyService;
+
+    /**
+     * @param TagsPropertyService $tagsPropertyService
+     */
+    public function __construct(TagsPropertyService $tagsPropertyService)
+    {
+        $this->tagsPropertyService = $tagsPropertyService;
+    }
+
+    /**
+     * @param PropertyDefinition $definition
+     * @param Notification $notification
+     */
+    public function build(PropertyDefinition $definition, Notification $notification)
+    {
+        $this->tagsPropertyService->fillPropertyDefinition($definition);
+    }
+}


### PR DESCRIPTION
Some events may exist without the need of having properties handling.

Methods in the event interface concerning the properties have been moved
to a new interface `HasProperties` which slightly alter how the system
works.

This interface is implemented by default in the `AbstractEvent`, so this
changes nothing for events that extend this class (unless they override
old methods that have been changed/deleted).

Some major refactoring works have been made so this might break your
installation. In this case, please read carefully the class
documentation blocks.

**Deleted methods**

- `\CuyZ\Notiz\Core\Event\Event::getProperties`

  This method was unnecessary and won't be replaced.

- `\CuyZ\Notiz\Core\Event\Event::buildPropertyDefinition`

  A new way of building the property definition is done using:
  `\CuyZ\Notiz\Core\Event\Support\HasProperties::getPropertyBuilder`

**Moved methods**

- `\CuyZ\Notiz\Core\Event\Event::fillPropertyEntries`

  This method has been moved to:
  `\CuyZ\Notiz\Core\Event\Support\HasProperties::fillPropertyEntries`

**Moved classes**

- `\CuyZ\Notiz\Core\Property\Support\PropertyBuilder`

  This class has been moved to:
  `\CuyZ\Notiz\Core\Property\Builder\PropertyBuilder`