### PR TITLE
[FEATURE] Allow getting event from full identifier in definition

### DIFF
--- a/Classes/Core/Definition/Tree/Definition.php
+++ b/Classes/Core/Definition/Tree/Definition.php
@@ -96,6 +96,35 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
     }
 
     /**
+     * @param string $fullIdentifier
+     * @return EventDefinition
+     *
+     * @throws EntryNotFoundException
+     */
+    public function getEventFromFullIdentifier($fullIdentifier)
+    {
+        if (!$this->hasEventFromFullIdentifier($fullIdentifier)) {
+            throw EntryNotFoundException::definitionEventFullIdentifierNotFound($fullIdentifier);
+        }
+
+        list($eventGroup, $event) = explode('.', $fullIdentifier);
+
+        return $this->getEventGroup($eventGroup)->getEvent($event);
+    }
+
+    /**
+     * @param string $fullIdentifier
+     * @return bool
+     */
+    public function hasEventFromFullIdentifier($fullIdentifier)
+    {
+        list($eventGroup, $event) = explode('.', $fullIdentifier);
+
+        return $this->hasEventGroup($eventGroup)
+            && $this->getEventGroup($eventGroup)->hasEvent($event);
+    }
+
+    /**
      * @return EventGroup
      */
     public function getFirstEventGroup()

--- a/Classes/Core/Exception/EntryNotFoundException.php
+++ b/Classes/Core/Exception/EntryNotFoundException.php
@@ -31,6 +31,8 @@ class EntryNotFoundException extends NotizException
 
     const DEFINITION_EVENT_NOT_FOUND = 'The event `%s` was not found, please use method `%s::hasEvent()`.';
 
+    const DEFINITION_EVENT_FULL_IDENTIFIER_NOT_FOUND = 'The event with a full identifier `%s` was not found.';
+
     const DEFINITION_NOTIFICATION_NOT_FOUND = 'The notification `%s` was not found, please use method `%s::hasNotification()`.';
 
     const ENTITY_EMAIL_VIEW_LAYOUT_NOT_FOUND = 'The view layout `%s` was not found, please use method `%s::hasLayout()`.';
@@ -96,6 +98,19 @@ class EntryNotFoundException extends NotizException
             self::DEFINITION_EVENT_NOT_FOUND,
             1503851804,
             [$identifier, EventGroup::class]
+        );
+    }
+
+    /**
+     * @param string $fullIdentifier
+     * @return static
+     */
+    public static function definitionEventFullIdentifierNotFound($fullIdentifier)
+    {
+        return self::makeNewInstance(
+            self::DEFINITION_EVENT_FULL_IDENTIFIER_NOT_FOUND,
+            1520251011,
+            [$fullIdentifier]
         );
     }
 


### PR DESCRIPTION
The full identifier of an event is composed of the identifier of the
event group and the identifier of the event itself. Both are separated
by a dot.