### PR TITLE
[FEATURE] Introduce preset argument for the event of a notification

### DIFF
--- a/Classes/Core/Notification/Service/NotificationTcaService.php
+++ b/Classes/Core/Notification/Service/NotificationTcaService.php
@@ -31,8 +31,6 @@ use CuyZ\Notiz\Service\LocalizationService;
 use CuyZ\Notiz\Service\StringService;
 use CuyZ\Notiz\Service\ViewService;
 use TYPO3\CMS\Core\SingletonInterface;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
-use TYPO3\CMS\Core\Utility\MathUtility;
 use TYPO3\CMS\Extbase\Persistence\Generic\Mapper\DataMapper;
 
 /**
@@ -155,21 +153,14 @@ abstract class NotificationTcaService implements SingletonInterface
         // The first configured event is selected by default.
         $event = $definition->getFirstEventGroup()->getFirstEvent();
 
-        // We check if the record already exists in the database...
-        if (MathUtility::canBeInterpretedAsInteger($row['uid'])) {
+        if (isset($row['event'])) {
             // @PHP7
             $eventValue = is_array($row['event'])
                 ? $row['event'][0]
                 : $row['event'];
 
-            list($eventGroupIdentifier, $eventIdentifier) = GeneralUtility::trimExplode('.', $eventValue);
-
-            if ($definition->hasEventGroup($eventGroupIdentifier)) {
-                $eventGroup = $definition->getEventGroup($eventGroupIdentifier);
-
-                if ($eventGroup->hasEvent($eventIdentifier)) {
-                    $event = $eventGroup->getEvent($eventIdentifier);
-                }
+            if ($definition->hasEventFromFullIdentifier($eventValue)) {
+                $event = $definition->getEventFromFullIdentifier($eventValue);
             }
         }
 

--- a/Classes/Core/Notification/TCA/EntityTcaWriter.php
+++ b/Classes/Core/Notification/TCA/EntityTcaWriter.php
@@ -18,6 +18,7 @@ namespace CuyZ\Notiz\Core\Notification\TCA;
 
 use CuyZ\Notiz\Core\Notification\Service\LegacyNotificationTcaService;
 use CuyZ\Notiz\Core\Notification\Service\NotificationTcaService;
+use CuyZ\Notiz\FormEngine\DataProvider\DefaultEventFromGet;
 use CuyZ\Notiz\Service\Traits\SelfInstantiateTrait;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
@@ -220,6 +221,7 @@ abstract class EntityTcaWriter implements SingletonInterface
             ],
             'searchFields' => 'title,event',
             'iconfile' => $this->service->getNotificationIconPath(),
+            DefaultEventFromGet::ENABLE_DEFAULT_VALUE => true,
         ];
     }
 

--- a/Classes/FormEngine/DataProvider/DefaultEventFromGet.php
+++ b/Classes/FormEngine/DataProvider/DefaultEventFromGet.php
@@ -45,7 +45,7 @@ class DefaultEventFromGet implements FormDataProviderInterface
             return $result;
         }
 
-        // The feature needs to be enable in the `ctrl` section of the TCA.
+        // The feature needs to be enabled in the `ctrl` section of the TCA.
         if (!isset($result['processedTca']['ctrl'][self::ENABLE_DEFAULT_VALUE])) {
             return $result;
         }

--- a/Classes/FormEngine/DataProvider/DefaultEventFromGet.php
+++ b/Classes/FormEngine/DataProvider/DefaultEventFromGet.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\FormEngine\DataProvider;
+
+use CuyZ\Notiz\Core\Definition\DefinitionService;
+use CuyZ\Notiz\Core\Definition\Tree\Definition;
+use CuyZ\Notiz\Service\Container;
+use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Will check if an argument `selectedEvent` exists in the request. If this
+ * argument matches an existing event, it will be selected for the field
+ * `event`.
+ *
+ * This service allows creating links for creating notifications in the form
+ * engine, with a chosen event selected by default.
+ */
+class DefaultEventFromGet implements FormDataProviderInterface
+{
+    const ENABLE_DEFAULT_VALUE = 'enableDefaultValue';
+
+    /**
+     * @param array $result
+     * @return array Result
+     */
+    public function addData(array $result)
+    {
+        // This feature is available for new records only.
+        if ($result['command'] !== 'new') {
+            return $result;
+        }
+
+        // The feature needs to be enable in the `ctrl` section of the TCA.
+        if (!isset($result['processedTca']['ctrl'][self::ENABLE_DEFAULT_VALUE])) {
+            return $result;
+        }
+
+        // The argument `selectedEvent` must exist in the request.
+        $selectedEvent = GeneralUtility::_GP('selectedEvent');
+
+        if (!$selectedEvent) {
+            return $result;
+        }
+
+        $definition = $this->getDefinition();
+
+        // The given event must be a valid identifier.
+        if (!$definition->hasEventFromFullIdentifier($selectedEvent)) {
+            return $result;
+        }
+
+        $result['databaseRow']['event'] = $selectedEvent;
+
+        return $result;
+    }
+
+    /**
+     * @return Definition
+     */
+    protected function getDefinition()
+    {
+        /** @var DefinitionService $definitionService */
+        $definitionService = Container::get(DefinitionService::class);
+
+        return $definitionService->getDefinition();
+    }
+}

--- a/Classes/Service/Extension/LocalConfigurationService.php
+++ b/Classes/Service/Extension/LocalConfigurationService.php
@@ -20,11 +20,14 @@ use CuyZ\Notiz\Backend\ToolBarItems\NotificationsToolbarItem;
 use CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder;
 use CuyZ\Notiz\Core\Support\NotizConstants;
 use CuyZ\Notiz\Domain\Definition\Builder\Component\DefaultDefinitionComponents;
+use CuyZ\Notiz\FormEngine\DataProvider\DefaultEventFromGet;
 use CuyZ\Notiz\Service\Container;
 use CuyZ\Notiz\Service\ExtensionConfigurationService;
 use CuyZ\Notiz\Service\Hook\EventDefinitionRegisterer;
 use CuyZ\Notiz\Service\Hook\NotificationFlexFormProcessor;
 use CuyZ\Notiz\Service\Traits\SelfInstantiateTrait;
+use TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRecordOverrideValues;
+use TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowDefaultValues;
 use TYPO3\CMS\Core\Cache\Backend\FileBackend;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 use TYPO3\CMS\Core\Database\TableConfigurationPostProcessingHookInterface;
@@ -82,6 +85,7 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
         $this->registerNotificationFlexFormProcessorHook();
         $this->registerInternalCache();
         $this->registerIcons();
+        $this->registerFormEngineComponents();
         $this->resetTypeConvertersArray();
         $this->overrideScheduler();
     }
@@ -221,5 +225,23 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
         if (ExtensionManagementUtility::isLoaded('scheduler')) {
             $GLOBALS['TYPO3_CONF_VARS']['SYS']['Objects'][Scheduler::class] = ['className' => \CuyZ\Notiz\Service\Scheduler\Scheduler::class];
         }
+    }
+
+    /**
+     * Registers components for TYPO3 form engine.
+     */
+    protected function registerFormEngineComponents()
+    {
+        /*
+         * A new data provider is registered for the form engine.
+         *
+         * It will be used to select a default value for the field `event` of a
+         * notification record, if an argument `selectedEvent` exists in the
+         * request and matches a valid event identifier.
+         */
+        $databaseRowDefaultValues = $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DatabaseRowDefaultValues::class];
+
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DefaultEventFromGet::class] = $databaseRowDefaultValues;
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DatabaseRecordOverrideValues::class]['depends'][] = DefaultEventFromGet::class;
     }
 }


### PR DESCRIPTION
An argument `selectedEvent` can be added to a request for the creation
of a new notification. This will give a default value to the event of
the notification.