### PR TITLE
[!!!][TASK] Make notification aware of the event it is bound to

### DIFF
--- a/Classes/Core/Notification/Notification.php
+++ b/Classes/Core/Notification/Notification.php
@@ -16,6 +16,8 @@
 
 namespace CuyZ\Notiz\Core\Notification;
 
+use CuyZ\Notiz\Core\Definition\Tree\EventGroup\Event\EventDefinition;
+
 /**
  * This interface must be implemented by notification classes that are
  * registered in the definition.
@@ -30,6 +32,13 @@ interface Notification
      * @return string
      */
     public static function getProcessorClassName();
+
+    /**
+     * Must return the event definition this notification is bound to.
+     *
+     * @return EventDefinition
+     */
+    public function getEventDefinition();
 
     /**
      * Must return a configuration array that will be used by the event during

--- a/Classes/Domain/Notification/EntityNotification.php
+++ b/Classes/Domain/Notification/EntityNotification.php
@@ -16,6 +16,9 @@
 
 namespace CuyZ\Notiz\Domain\Notification;
 
+use CuyZ\Notiz\Core\Definition\DefinitionService;
+use CuyZ\Notiz\Core\Definition\Tree\Definition;
+use CuyZ\Notiz\Core\Definition\Tree\EventGroup\Event\EventDefinition;
 use CuyZ\Notiz\Core\Definition\Tree\Notification\Channel\ChannelDefinition;
 use CuyZ\Notiz\Core\Notification\MultipleChannelsNotification;
 use CuyZ\Notiz\Core\Notification\Notification;
@@ -107,6 +110,14 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     }
 
     /**
+     * @return EventDefinition
+     */
+    public function getEventDefinition()
+    {
+        return $this->getDefinition()->getEventFromFullIdentifier($this->getEvent());
+    }
+
+    /**
      * Returns the event configuration stored as a FlexForm string.
      *
      * @return array
@@ -131,5 +142,13 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     public function shouldDispatch(ChannelDefinition $definition)
     {
         return $definition->getClassName() === $this->getChannel();
+    }
+
+    /**
+     * @return Definition
+     */
+    protected function getDefinition()
+    {
+        return DefinitionService::get()->getDefinition();
     }
 }


### PR DESCRIPTION
A new method is added to the notification interface, that must return
the event definition it is bound to.