### PR TITLE
[BUGFIX] Make notification entity title static

### DIFF
--- a/Classes/Core/Notification/TCA/EntityTcaWriter.php
+++ b/Classes/Core/Notification/TCA/EntityTcaWriter.php
@@ -108,6 +108,13 @@ abstract class EntityTcaWriter implements SingletonInterface
     abstract protected function getNotificationTcaServiceClass();
 
     /**
+     * Returns the title of the entity, can be a LLL reference.
+     *
+     * @return string
+     */
+    abstract protected function getEntityTitle();
+
+    /**
      * This method returns the LLL string to use for the `channel` column.
      *
      * @return string
@@ -202,6 +209,8 @@ abstract class EntityTcaWriter implements SingletonInterface
     protected function getDefaultCtrl()
     {
         return [
+            'title' => $this->getEntityTitle(),
+
             'label' => 'title',
             'tstamp' => 'tstamp',
             'crdate' => 'crdate',

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaWriter.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaWriter.php
@@ -257,10 +257,17 @@ class EntityEmailTcaWriter extends EntityTcaWriter
     {
         $ctrl = $this->getDefaultCtrl();
 
-        $ctrl['title'] = self::EMAIL_LLL . ':title';
         $ctrl['requestUpdate'] .= ',sender_custom';
         $ctrl['searchFields'] .= ',sender,sender_custom,send_to,send_to_provided,send_cc,send_cc_provided,send_bcc,send_bcc_provided,subject,body';
 
         return $ctrl;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getEntityTitle()
+    {
+        return self::EMAIL_LLL . ':title';
     }
 }

--- a/Classes/Domain/Notification/Log/Application/EntityLog/TCA/EntityLogTcaWriter.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/TCA/EntityLogTcaWriter.php
@@ -44,7 +44,7 @@ class EntityLogTcaWriter extends EntityTcaWriter
     protected function buildTcaArray()
     {
         return [
-            'ctrl' => $this->getCtrl(),
+            'ctrl' => $this->getDefaultCtrl(),
 
             'palettes' => [
                 'content' => [
@@ -111,14 +111,10 @@ class EntityLogTcaWriter extends EntityTcaWriter
     }
 
     /**
-     * @return array
+     * @return string
      */
-    protected function getCtrl()
+    protected function getEntityTitle()
     {
-        $ctrl = $this->getDefaultCtrl();
-
-        $ctrl['title'] = self::LOG_LLL . ':title';
-
-        return $ctrl;
+        return self::LOG_LLL . ':title';
     }
 }

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
@@ -198,7 +198,6 @@ class EntitySlackTcaWriter extends EntityTcaWriter
     {
         $ctrl = $this->getDefaultCtrl();
 
-        $ctrl['title'] = self::SLACK_LLL . ':title';
         $ctrl['requestUpdate'] .= ',custom_bot';
 
         return $ctrl;
@@ -210,5 +209,13 @@ class EntitySlackTcaWriter extends EntityTcaWriter
     protected function getNotificationTcaServiceClass()
     {
         return EntitySlackTcaService::class;
+    }
+
+    /**
+     * @return string
+     */
+    protected function getEntityTitle()
+    {
+        return self::SLACK_LLL . ':title';
     }
 }


### PR DESCRIPTION
When an error was found in definition, the current implementation would
not show the title of the notification; this was leading to
misunderstanding in certain modules, for instance in a backend usergroup
record access list.