### PR TITLE
[FEATURE] Add a v7/v8 compatible backend icon ViewHelper

### DIFF
--- a/Classes/ViewHelpers/Core/IconViewHelper.php
+++ b/Classes/ViewHelpers/Core/IconViewHelper.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\ViewHelpers\Core;
+
+use Closure;
+use TYPO3\CMS\Core\Imaging\Icon;
+use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Type\Icon\IconState;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Fluid\Core\Rendering\RenderingContextInterface;
+use TYPO3\CMS\Fluid\Core\ViewHelper\Facets\CompilableInterface;
+use TYPO3\CMS\Fluid\ViewHelpers\Be\AbstractBackendViewHelper;
+
+/**
+ * @deprecated Must be removed when TYPO3 v7 is not supported anymore.
+ *
+ * In TYPO3 v7: <f:be.buttons.icon icon="foo" />
+ * In TYPO3 v8: <core:icon identifier="foo" />
+ * This ViewHelper: <nz:core.icon identifier="foo" />
+ */
+class IconViewHelper extends AbstractBackendViewHelper implements CompilableInterface
+{
+    /**
+     * View helper returns HTML, thus we need to disable output escaping
+     *
+     * @var bool
+     */
+    protected $escapeOutput = false;
+
+    /**
+     * Initializes the arguments
+     */
+    public function initializeArguments()
+    {
+        parent::initializeArguments();
+        $this->registerArgument('identifier', 'string', 'the table for the record icon', true);
+        $this->registerArgument('size', 'string', 'the icon size', false, Icon::SIZE_SMALL);
+        $this->registerArgument('overlay', 'string', '', false, null);
+        $this->registerArgument('state', 'string', '', false, IconState::STATE_DEFAULT);
+        $this->registerArgument('alternativeMarkupIdentifier', 'string', '', false, null);
+    }
+
+    /**
+     * @return string
+     */
+    public function render()
+    {
+        return static::renderStatic(
+            $this->arguments,
+            $this->buildRenderChildrenClosure(),
+            $this->renderingContext
+        );
+    }
+
+    /**
+     * Prints icon html for $identifier key
+     *
+     * @param array $arguments
+     * @param Closure $renderChildrenClosure
+     * @param RenderingContextInterface $renderingContext
+     * @return string
+     */
+    public static function renderStatic(array $arguments, Closure $renderChildrenClosure, RenderingContextInterface $renderingContext)
+    {
+        $identifier = $arguments['identifier'];
+        $size = $arguments['size'];
+        $overlay = $arguments['overlay'];
+        $state = IconState::cast($arguments['state']);
+        $alternativeMarkupIdentifier = $arguments['alternativeMarkupIdentifier'];
+        /** @var IconFactory $iconFactory */
+        $iconFactory = GeneralUtility::makeInstance(IconFactory::class);
+        return $iconFactory->getIcon($identifier, $size, $overlay, $state)->render($alternativeMarkupIdentifier);
+    }
+}

--- a/Resources/Private/Partials/Backend/Administration/HeaderButtons.html
+++ b/Resources/Private/Partials/Backend/Administration/HeaderButtons.html
@@ -1,7 +1,9 @@
+{namespace nz=CuyZ\Notiz\ViewHelpers}
+
 <f:section name="Buttons">
     <f:link.action action="index" class="btn btn-default" title="{nz:t(key: 'Backend/Module/Administration/Layout:menu.index')}">
         <strong>
-            <core:icon identifier="actions-online-media-add" />
+            <nz:core.icon identifier="actions-online-media-add" />
             <nz:t key="Backend/Module/Administration/Layout:menu.index" />
         </strong>
     </f:link.action>
@@ -10,7 +12,7 @@
         <f:then>
             <f:link.action action="showDefinition" class="btn btn-primary" title="{nz:t(key: 'Backend/Module/Administration/Definition/Show:refresh')}">
                 <strong>
-                    <core:icon identifier="actions-refresh" />
+                    <nz:core.icon identifier="actions-refresh" />
                     <nz:t key="Backend/Module/Administration/Definition/Show:refresh" />
                 </strong>
             </f:link.action>
@@ -18,7 +20,7 @@
         <f:else>
             <f:link.action action="showDefinition" class="btn btn-primary" title="{nz:t(key: 'Backend/Module/Main/Module:label.show_definition')}">
                 <strong>
-                    <core:icon identifier="actions-view" />
+                    <nz:core.icon identifier="actions-view" />
                     <nz:t key="Backend/Module/Main/Module:label.show_definition" />
 
                     <f:if condition="{result.flattenedErrors}">

--- a/Resources/Private/Templates/Backend/Administration/ShowDefinition.html
+++ b/Resources/Private/Templates/Backend/Administration/ShowDefinition.html
@@ -88,7 +88,7 @@
                                     <div class="text-center">
                                         <f:link.action action="showException" class="text-center btn btn-default" target="_blank">
                                             <strong>
-                                                <core:icon identifier="overlay-missing" />
+                                                <nz:core.icon identifier="overlay-missing" />
                                                 <nz:t key="Backend/Module/Administration/Definition/Error:info_box.exception.open_in_new_tab" />
                                             </strong>
                                         </f:link.action>
@@ -115,7 +115,7 @@
 
 <f:section name="DefinitionTree">
     <span class="root-definition">
-        <core:icon identifier="tx-notiz-icon" size="default" />
+        <nz:core.icon identifier="tx-notiz-icon" size="default" />
         <nz:t key="Backend/Module/Administration/Definition/Show:definition_tree.root" />
     </span>
 
@@ -159,7 +159,7 @@
                 <span class="notiz-definition-entry">
                     <label>
                         <span title="{nz:t(key: 'Backend/Module/Administration/Definition/Show:definition_tree.label_show_full_path')}">
-                            <core:icon identifier="apps-pagetree-page-shortcut-external" />
+                            <nz:core.icon identifier="apps-pagetree-page-shortcut-external" />
                         </span>
 
                         <input type="checkbox" />
@@ -199,13 +199,13 @@
 <f:section name="Messages">
     <f:for each="{messages}" as="message">
         <li>
-            <core:icon identifier="{icon}" />
+            <nz:core.icon identifier="{icon}" />
 
             <span class="{background}" title="code: {message.code}">{message -> nz:mark()}</span>
 
             <span class="notiz-definition-entry">
                 <label>
-                    <core:icon identifier="actions-search" />
+                    <nz:core.icon identifier="actions-search" />
 
                     <input type="checkbox" />
 

--- a/Resources/Private/Templates/Backend/TCA/DefinitionErrorMessage.html
+++ b/Resources/Private/Templates/Backend/TCA/DefinitionErrorMessage.html
@@ -15,7 +15,7 @@
     <p>
         <nz:backend.module.link module="Administration"
                                 action="showDefinition">
-            <core:icon identifier="actions-system-extension-configure" />
+            <nz:core.icon identifier="actions-system-extension-configure" />
             <nz:t key="Backend/Module/Administration/Definition/Error:errors_link.label"
                   args="{0: '{result.flattenedErrors -> f:count()}'}" />
         </nz:backend.module.link>

--- a/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarDropDown.html
+++ b/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarDropDown.html
@@ -14,7 +14,7 @@
     <nz:backend.module.link module="Administration"
                             action="showDefinition"
                             frame="1">
-        <core:icon identifier="actions-system-extension-configure" alternativeMarkupIdentifier="inline" />
+        <nz:core.icon identifier="actions-system-extension-configure" alternativeMarkupIdentifier="inline" />
         <nz:t key="Backend/Toolbar/Show:body.show_definition" />
     </nz:backend.module.link>
 </f:section>
@@ -28,7 +28,7 @@
 </f:section>
 
 <f:section name="BodyNotificationIcon">
-    <core:icon identifier="{notification.iconIdentifier}" alternativeMarkupIdentifier="inline" />
+    <nz:core.icon identifier="{notification.iconIdentifier}" alternativeMarkupIdentifier="inline" />
 </f:section>
 
 <f:section name="BodyNotificationIdentifier">
@@ -51,7 +51,7 @@
     <nz:backend.module.link module="Administration"
                             action="showDefinition"
                             frame="1">
-        <core:icon identifier="actions-search" alternativeMarkupIdentifier="inline" />
+        <nz:core.icon identifier="actions-search" alternativeMarkupIdentifier="inline" />
         <nz:t key="Backend/Module/Administration/Definition/Error:errors_link.label"
               args="{0: '{result.flattenedErrors -> f:count()}'}" />
     </nz:backend.module.link>

--- a/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarItem.html
+++ b/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarItem.html
@@ -10,12 +10,12 @@
         </f:comment>
         <f:if condition="{result.flattenedErrors}">
             <f:then>
-                <core:icon identifier="tx-notiz-icon-toolbar"
+                <nz:core.icon identifier="tx-notiz-icon-toolbar"
                            alternativeMarkupIdentifier="inline"
                            overlay="overlay-missing" />
             </f:then>
             <f:else>
-                <core:icon identifier="tx-notiz-icon-toolbar"
+                <nz:core.icon identifier="tx-notiz-icon-toolbar"
                            alternativeMarkupIdentifier="inline" />
             </f:else>
         </f:if>


### PR DESCRIPTION
This ViewHelper is needed to stay compatible with TYPO3 v7 and v8 without having to check the version eveytime.

In TYPO3 v7: `<f:be.buttons.icon icon="foo" />`
In TYPO3 v8: `<core:icon identifier="foo" />`
This ViewHelper: `<nz:core.icon identifier="foo" />`