### PR TITLE
[FEATURE] Add asynchronous refresh to the notification toolbar

### DIFF
--- a/Classes/Backend/ToolBarItems/NotificationsToolbarItem.php
+++ b/Classes/Backend/ToolBarItems/NotificationsToolbarItem.php
@@ -17,13 +17,17 @@
 namespace CuyZ\Notiz\Backend\ToolBarItems;
 
 use CuyZ\Notiz\Core\Definition\DefinitionService;
+use CuyZ\Notiz\Service\Container;
 use CuyZ\Notiz\Service\ExtensionConfigurationService;
 use CuyZ\Notiz\Service\LocalizationService;
 use CuyZ\Notiz\Service\ViewService;
 use Exception;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Toolbar\ToolbarItemInterface;
 use TYPO3\CMS\Core\Imaging\IconFactory;
+use TYPO3\CMS\Core\Page\PageRenderer;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
@@ -34,6 +38,21 @@ use TYPO3\CMS\Fluid\View\StandaloneView;
  */
 class NotificationsToolbarItem implements ToolbarItemInterface
 {
+    /**
+     * If true, all information will be added to the toolbar menu.
+     *
+     * The first run of the toolbar rendering (during the rendering of the TYPO3
+     * backend) wont be full. This can improve performance if a lot of
+     * notifications were to be listed.
+     *
+     * Periodic asynchronous requests will be dispatched when the TYPO3 backend
+     * is rendered. These Ajax requests will contain all information, as they
+     * are running as background tasks.
+     *
+     * @var bool
+     */
+    protected $fullMenu = false;
+
     /**
      * @var IconFactory
      */
@@ -66,6 +85,8 @@ class NotificationsToolbarItem implements ToolbarItemInterface
         $this->definitionService = $objectManager->get(DefinitionService::class);
         $this->extensionConfigurationService = $objectManager->get(ExtensionConfigurationService::class);
         $this->viewService = $objectManager->get(ViewService::class);
+
+        $this->initializeJavaScript();
     }
 
     /**
@@ -97,36 +118,30 @@ class NotificationsToolbarItem implements ToolbarItemInterface
      */
     public function getDropDown()
     {
-        $exception = null;
-        $result = '';
-
         try {
-            $result = $this->getDropDownFromDefinition();
+            return $this->getDropDownFromDefinition();
         } catch (Throwable $exception) {
         } catch (Exception $exception) {
             // @PHP7
         }
 
-        if ($exception) {
-            $lllException = LocalizationService::localize('Backend/Toolbar/Error:exception');
-            $lllExceptionCode = LocalizationService::localize('Backend/Toolbar/Error:exception.code');
-            $lllExceptionMessage = LocalizationService::localize('Backend/Toolbar/Error:exception.message');
+        return $this->getErrorDropDown($exception);
+    }
 
-            $result = '<p class="text-danger">' . $lllException . '</p>
-                <hr />
-                <dl>';
+    /**
+     * Action called periodically by Ajax (used to refresh the toolbar).
+     *
+     * @param ServerRequestInterface $request
+     * @param ResponseInterface $response
+     * @return ResponseInterface
+     */
+    public function renderMenuAction(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        $this->fullMenu = true;
 
-            if ($exception->getCode()) {
-                $result .= '<dt>' . $lllExceptionCode . '</dt>
-                    <dd>' . $exception->getCode() . '</dd>';
-            }
+        $response->getBody()->write($this->getDropDown());
 
-            $result .= '<dt>' . $lllExceptionMessage . '</dt>
-                <dd>' . $exception->getMessage() . '</dd>
-                </dl>';
-        }
-
-        return $result;
+        return $response->withHeader('Content-Type', 'text/html; charset=utf-8');
     }
 
     /**
@@ -138,22 +153,40 @@ class NotificationsToolbarItem implements ToolbarItemInterface
 
         if (!$this->definitionService->getValidationResult()->hasErrors()) {
             $definition = $this->definitionService->getDefinition();
-            $notifications = [];
-            $total = 0;
 
-            foreach ($definition->getNotifications() as $notification) {
-                $number = $notification->getProcessor()->getTotalNumber();
-                $total += $number;
-
-                if ($number > 0) {
-                    $notifications[] = $notification;
-                }
-            }
-
+            $view->assign('fullMenu', $this->fullMenu);
             $view->assign('definition', $definition);
-            $view->assign('filledNotifications', $notifications);
-            $view->assign('filledNotificationsTotal', $total);
+
+            if ($this->fullMenu) {
+                $notifications = [];
+                $total = 0;
+
+                foreach ($definition->getNotifications() as $notification) {
+                    $number = $notification->getProcessor()->getTotalNumber();
+                    $total += $number;
+
+                    if ($number > 0) {
+                        $notifications[] = $notification;
+                    }
+                }
+
+                $view->assign('filledNotifications', $notifications);
+                $view->assign('filledNotificationsTotal', $total);
+            }
         }
+
+        return $view->render();
+    }
+
+    /**
+     * @param Throwable $exception
+     * @return string
+     */
+    protected function getErrorDropDown($exception)
+    {
+        $view = $this->getFluidTemplateObject('Backend/ToolBar/NotificationToolBarDropDownError');
+        $view->assign('exception', $exception);
+        $view->assign('isAdmin', Container::getBackendUser()->isAdmin());
 
         return $view->render();
     }
@@ -177,6 +210,21 @@ class NotificationsToolbarItem implements ToolbarItemInterface
     }
 
     /**
+     * Requires the JavaScript script that will refresh the toolbar every now
+     * and then.
+     */
+    protected function initializeJavaScript()
+    {
+        $pageRenderer = $this->getPageRenderer();
+
+        $pageRenderer->loadRequireJsModule('TYPO3/CMS/Notiz/Toolbar');
+        $pageRenderer->addInlineLanguageLabelArray([
+            'notiz.toolbar.error.body' => LocalizationService::localize('Backend/Toolbar/Error:exception'),
+            'notiz.toolbar.error.refresh_label' => LocalizationService::localize('Backend/Toolbar/Show:refresh'),
+        ]);
+    }
+
+    /**
      * @param string $templateName
      * @return StandaloneView
      */
@@ -190,5 +238,13 @@ class NotificationsToolbarItem implements ToolbarItemInterface
         $view->assign('legacyLayout', $legacyLayout);
 
         return $view;
+    }
+
+    /**
+     * @return PageRenderer|object
+     */
+    protected function getPageRenderer()
+    {
+        return GeneralUtility::makeInstance(PageRenderer::class);
     }
 }

--- a/Classes/Service/Container.php
+++ b/Classes/Service/Container.php
@@ -17,6 +17,7 @@
 namespace CuyZ\Notiz\Service;
 
 use CuyZ\Notiz\Service\Traits\ExtendedSelfInstantiateTrait;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Extbase\Object\ObjectManager;
 
@@ -47,5 +48,13 @@ class Container implements SingletonInterface
     public static function get($className, ...$arguments)
     {
         return static::getInstance()->objectManager->get($className, ...$arguments);
+    }
+
+    /**
+     * @return BackendUserAuthentication
+     */
+    public static function getBackendUser()
+    {
+        return $GLOBALS['BE_USER'];
     }
 }

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+return [
+    'notiz_render_toolbar' => [
+        'path' => '/notiz/render-toolbar',
+        'target' => \CuyZ\Notiz\Backend\ToolBarItems\NotificationsToolbarItem::class . '::renderMenuAction'
+    ],
+];

--- a/Resources/Private/Language/Backend/Toolbar/Show.xlf
+++ b/Resources/Private/Language/Backend/Toolbar/Show.xlf
@@ -12,6 +12,10 @@
                 <source>NotiZ information</source>
             </trans-unit>
 
+            <trans-unit id="body.simple_menu">
+                <source>Notifications definition is valid: all notifications will be dispatched properly.</source>
+            </trans-unit>
+
             <trans-unit id="body.show_definition">
                 <source>Show current definition</source>
             </trans-unit>
@@ -24,6 +28,23 @@
             </trans-unit>
             <trans-unit id="body.notification_label">
                 <source>%s notification(s)</source>
+            </trans-unit>
+
+            <trans-unit id="flash.ok.title">
+                <source>Notifications are active</source>
+            </trans-unit>
+            <trans-unit id="flash.ok.body">
+                <source>Notifications definition is valid: all notifications will be dispatched properly.</source>
+            </trans-unit>
+            <trans-unit id="flash.error.title">
+                <source>Notifications are disabled</source>
+            </trans-unit>
+            <trans-unit id="flash.error.body">
+                <source>At least one error was found in the notifications definition. All notifications are disabled until definition is valid again.</source>
+            </trans-unit>
+
+            <trans-unit id="refresh">
+                <source>Refresh</source>
             </trans-unit>
 
         </body>

--- a/Resources/Private/Language/Backend/Toolbar/de.Show.xlf
+++ b/Resources/Private/Language/Backend/Toolbar/de.Show.xlf
@@ -12,6 +12,10 @@
                 <target>NotiZ-Information</target>
             </trans-unit>
 
+            <trans-unit id="body.simple_menu">
+                <target>TODO DE: Notifications definition is valid: all notifications will be dispatched properly.</target>
+            </trans-unit>
+
             <trans-unit id="body.show_definition">
                 <target>Aktuelle Definition anzeigen</target>
             </trans-unit>
@@ -24,6 +28,23 @@
             </trans-unit>
             <trans-unit id="body.notification_label">
                 <target>%s Benachrichtigung(en)</target>
+            </trans-unit>
+
+            <trans-unit id="flash.ok.title">
+                <target>TODO DE: Notifications are active</target>
+            </trans-unit>
+            <trans-unit id="flash.ok.body">
+                <target>TODO DE: Notifications definition is valid: all notifications will be dispatched properly.</target>
+            </trans-unit>
+            <trans-unit id="flash.error.title">
+                <target>TODO DE: Notifications are disabled</target>
+            </trans-unit>
+            <trans-unit id="flash.error.body">
+                <target>TODO DE: At least one error was found in the notifications definition. All notifications are disabled until definition is valid again.</target>
+            </trans-unit>
+
+            <trans-unit id="refresh">
+                <target>TODO DE: Refresh</target>
             </trans-unit>
 
         </body>

--- a/Resources/Private/Language/Backend/Toolbar/fr.Show.xlf
+++ b/Resources/Private/Language/Backend/Toolbar/fr.Show.xlf
@@ -12,6 +12,10 @@
                 <target>Information NotiZ</target>
             </trans-unit>
 
+            <trans-unit id="body.simple_menu">
+                <target>La définition des notifications est valide : toutes les notifications seront traitées correctement.</target>
+            </trans-unit>
+
             <trans-unit id="body.show_definition">
                 <target>Montrer la définition actuelle</target>
             </trans-unit>
@@ -24,6 +28,23 @@
             </trans-unit>
             <trans-unit id="body.notification_label">
                 <target>%s notification(s)</target>
+            </trans-unit>
+
+            <trans-unit id="flash.ok.title">
+                <target>Les notifications sont actives</target>
+            </trans-unit>
+            <trans-unit id="flash.ok.body">
+                <target>La définition des notifications est valide : toutes les notifications seront traitées correctement.</target>
+            </trans-unit>
+            <trans-unit id="flash.error.title">
+                <target>Les notifications sont désactivées</target>
+            </trans-unit>
+            <trans-unit id="flash.error.body">
+                <target>Au moins une erreur a été trouvée dans la définition des notifications. Toutes les notifications seront désactivées jusqu'à ce que la définition soit valide.</target>
+            </trans-unit>
+
+            <trans-unit id="refresh">
+                <target>Rafraîchir</target>
             </trans-unit>
 
         </body>

--- a/Resources/Private/Layouts/Backend/ToolBar/DropDown/Default.html
+++ b/Resources/Private/Layouts/Backend/ToolBar/DropDown/Default.html
@@ -1,3 +1,5 @@
+<f:render section="DataContainer" />
+
 <h3 class="dropdown-headline">
     <f:render section="BodyTitle" />
 </h3>
@@ -17,10 +19,21 @@
         <p class="dropdown-text">
             <f:render section="BodyErrorsLink" />
         </p>
+
+        <hr />
+
+        <p class="dropdown-text">
+            <f:render partial="Backend/Toolbar/RefreshToolbar" section="Content" />
+        </p>
     </f:then>
     <f:else>
-        <f:if condition="{filledNotifications}">
+        <f:if condition="!{fullMenu}">
             <f:then>
+                <p class="dropdown-text text-success">
+                    <f:render section="BodySimpleMenu" />
+                </p>
+            </f:then>
+            <f:else if="{filledNotifications}">
                 <p class="dropdown-text">
                     <f:render section="BodyDescriptionNotification" />
                 </p>
@@ -40,7 +53,7 @@
                         </div>
                     </f:for>
                 </div>
-            </f:then>
+            </f:else>
             <f:else>
                 <p class="dropdown-text">
                     <span class="text-warning">
@@ -49,11 +62,16 @@
                 </p>
             </f:else>
         </f:if>
-
         <hr />
 
         <p class="dropdown-text">
             <f:render section="BodyDefinitionLink" />
+        </p>
+
+        <hr />
+
+        <p class="dropdown-text">
+            <f:render partial="Backend/Toolbar/RefreshToolbar" section="Content" />
         </p>
     </f:else>
 </f:if>

--- a/Resources/Private/Layouts/Backend/ToolBar/DropDown/Legacy.html
+++ b/Resources/Private/Layouts/Backend/ToolBar/DropDown/Legacy.html
@@ -2,6 +2,8 @@
     Layout used for TYPO3 7.6
 </f:comment>
 
+<f:render section="DataContainer" />
+
 <ul class="dropdown-list">
     <li class="dropdown-header">
         <f:render section="BodyTitle" />
@@ -19,36 +21,50 @@
 
             <li>
                 <f:render section="BodyErrorsLink" />
+            </li>
 
+            <li class="divider"></li>
+
+            <li>
+                <f:render partial="Backend/Toolbar/RefreshToolbar" section="Content" />
             </li>
         </f:then>
         <f:else>
-            <f:if condition="{filledNotifications}">
+            <f:if condition="{fullMenu}">
                 <f:then>
-                    <li class="dropdown-intro">
-                        <f:render section="BodyDescriptionNotification" />
-                    </li>
+                    <f:if condition="{filledNotifications}">
+                        <f:then>
+                            <li class="dropdown-intro">
+                                <f:render section="BodyDescriptionNotification" />
+                            </li>
 
-                    <li>
-                        <dl class="dl-horizontal">
-                            <f:for each="{filledNotifications}" as="notification">
-                                <dt title="{notification.label}">
-                                    <f:render section="BodyNotificationIcon" arguments="{notification: notification}" />
-                                    <f:render section="BodyNotificationIdentifier" arguments="{notification: notification}" />
-                                </dt>
-                                <dd>
-                                    <f:render section="BodyNotificationLabel" arguments="{notification: notification}" />
-                                </dd>
-                            </f:for>
-                        </dl>
-                    </li>
-                </f:then>
-                <f:else>
-                    <li class="dropdown-intro">
+                            <li>
+                                <dl class="dl-horizontal">
+                                    <f:for each="{filledNotifications}" as="notification">
+                                        <dt title="{notification.label}">
+                                            <f:render section="BodyNotificationIcon" arguments="{notification: notification}" />
+                                            <f:render section="BodyNotificationIdentifier" arguments="{notification: notification}" />
+                                        </dt>
+                                        <dd>
+                                            <f:render section="BodyNotificationLabel" arguments="{notification: notification}" />
+                                        </dd>
+                                    </f:for>
+                                </dl>
+                            </li>
+                        </f:then>
+                        <f:else>
+                            <li class="dropdown-intro">
                         <span class="text-warning">
                             <f:render section="BodyDescriptionNoNotification" />
                         </span>
-                    </li>
+                            </li>
+                        </f:else>
+                    </f:if>
+                </f:then>
+                <f:else>
+                    <p class="dropdown-text text-success">
+                        <f:render section="BodySimpleMenu" />
+                    </p>
                 </f:else>
             </f:if>
 
@@ -56,6 +72,12 @@
 
             <li>
                 <f:render section="BodyDefinitionLink" />
+            </li>
+
+            <li class="divider"></li>
+
+            <li>
+                <f:render partial="Backend/Toolbar/RefreshToolbar" section="Content" />
             </li>
         </f:else>
     </f:if>

--- a/Resources/Private/Layouts/Backend/ToolBar/DropDownError/Default.html
+++ b/Resources/Private/Layouts/Backend/ToolBar/DropDownError/Default.html
@@ -1,0 +1,27 @@
+<p class="dropdown-text text-danger">
+    <nz:t key="Backend/Toolbar/Error:exception" />
+</p>
+
+<f:if condition="{isAdmin}">
+    <hr />
+
+    <dl>
+        <f:if condition="{exception.code}">
+            <dt>
+                <nz:t key="Backend/Toolbar/Error:exception.code" />
+            </dt>
+            <dt>{exception.code}</dt>
+        </f:if>
+
+        <dt>
+            <nz:t key="Backend/Toolbar/Error:exception.message" />
+        </dt>
+        <dt>{exception.message}</dt>
+    </dl>
+</f:if>
+
+<hr />
+
+<p class="dropdown-text">
+    <f:render partial="Backend/Toolbar/RefreshToolbar" section="Content" />
+</p>

--- a/Resources/Private/Layouts/Backend/ToolBar/DropDownError/Legacy.html
+++ b/Resources/Private/Layouts/Backend/ToolBar/DropDownError/Legacy.html
@@ -1,0 +1,33 @@
+{namespace nz=CuyZ\Notiz\ViewHelpers}
+
+<ul class="dropdown-list">
+    <li class="text-danger">
+        <nz:t key="Backend/Toolbar/Error:exception" />
+    </li>
+
+    <f:if condition="{isAdmin}">
+        <li class="divider"></li>
+
+        <li>
+            <dl class="dl-horizontal">
+                <f:if condition="{exception.code}">
+                    <dt>
+                        <nz:t key="Backend/Toolbar/Error:exception.code" />
+                    </dt>
+                    <dt>{exception.code}</dt>
+                </f:if>
+
+                <dt>
+                    <nz:t key="Backend/Toolbar/Error:exception.message" />
+                </dt>
+                <dt>{exception.message}</dt>
+            </dl>
+        </li>
+    </f:if>
+
+    <li class="divider"></li>
+
+    <li>
+        <f:render partial="Backend/Toolbar/RefreshToolbar" section="Content" />
+    </li>
+</ul>

--- a/Resources/Private/Partials/Backend/Toolbar/RefreshToolbar.html
+++ b/Resources/Private/Partials/Backend/Toolbar/RefreshToolbar.html
@@ -1,0 +1,8 @@
+{namespace nz=CuyZ\Notiz\ViewHelpers}
+
+<f:section name="Content">
+    <a href="#" onclick="TYPO3.NotificationToolbar.menu.refresh();">
+        <nz:core.icon identifier="actions-refresh" alternativeMarkupIdentifier="inline" />
+        <nz:t key="Backend/Toolbar/Show:refresh" />
+    </a>
+</f:section>

--- a/Resources/Private/Partials/Backend/Toolbar/RefreshToolbar.html
+++ b/Resources/Private/Partials/Backend/Toolbar/RefreshToolbar.html
@@ -1,7 +1,7 @@
 {namespace nz=CuyZ\Notiz\ViewHelpers}
 
 <f:section name="Content">
-    <a href="#" onclick="TYPO3.NotificationToolbar.menu.refresh();">
+    <a href="javascript:void(0);" onclick="TYPO3.NotificationToolbar.menu.refresh();">
         <nz:core.icon identifier="actions-refresh" alternativeMarkupIdentifier="inline" />
         <nz:t key="Backend/Toolbar/Show:refresh" />
     </a>

--- a/Resources/Private/Partials/Backend/Toolbar/ToolbarIcon.html
+++ b/Resources/Private/Partials/Backend/Toolbar/ToolbarIcon.html
@@ -1,0 +1,18 @@
+{namespace nz=CuyZ\Notiz\ViewHelpers}
+
+<f:section name="Content">
+    <f:comment>
+        Change as inline code when https://review.typo3.org/#/c/54212/ is merged.
+    </f:comment>
+    <f:if condition="{result.flattenedErrors}">
+        <f:then>
+            <nz:core.icon identifier="tx-notiz-icon-toolbar"
+                       alternativeMarkupIdentifier="inline"
+                       overlay="overlay-missing"/>
+        </f:then>
+        <f:else>
+            <nz:core.icon identifier="tx-notiz-icon-toolbar"
+                       alternativeMarkupIdentifier="inline"/>
+        </f:else>
+    </f:if>
+</f:section>

--- a/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarDropDown.html
+++ b/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarDropDown.html
@@ -39,6 +39,10 @@
     <nz:t key="Backend/Toolbar/Show:body.notification_label" args="{0: notification.processor.totalNumber}" />
 </f:section>
 
+<f:section name="BodySimpleMenu">
+    <nz:t key="Backend/Toolbar/Show:body.simple_menu" />
+</f:section>
+
 ********************************************************************************
 *** ERRORS
 ********************************************************************************
@@ -55,4 +59,23 @@
         <nz:t key="Backend/Module/Administration/Definition/Error:errors_link.label"
               args="{0: '{result.flattenedErrors -> f:count()}'}" />
     </nz:backend.module.link>
+</f:section>
+
+********************************************************************************
+*** DATA CONTAINER (used by Ajax request for toolbar refresh)
+********************************************************************************
+<f:section name="DataContainer">
+    <f:alias map="{key: '{f:if(condition: \'{result.flattenedErrors}\', then: \'error\', else: \'ok\')}'}">
+        <span class="t3js-notiz-data-container"
+              data-error="{f:if(condition: '{result.flattenedErrors}', then: '1')}"
+              data-message-title="{nz:t(key: 'Backend/Toolbar/Show:flash.{key}.title')}"
+              data-message-body="{nz:t(key: 'Backend/Toolbar/Show:flash.{key}.body')}"
+        ></span>
+    </f:alias>
+
+    <div class="t3js-notiz-icon hidden">
+        <f:render partial="Backend/Toolbar/ToolbarIcon"
+                  section="Content"
+                  arguments="{result: result}" />
+    </div>
 </f:section>

--- a/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarDropDownError.html
+++ b/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarDropDownError.html
@@ -1,0 +1,3 @@
+{namespace nz=CuyZ\Notiz\ViewHelpers}
+
+<f:layout name="Backend/ToolBar/DropDownError/{f:if(condition: legacyLayout, then: 'Legacy', else: 'Default')}" />

--- a/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarItem.html
+++ b/Resources/Private/Templates/Backend/ToolBar/NotificationToolBarItem.html
@@ -5,20 +5,9 @@
 
 <f:section name="Icon">
     <span title="{nz:t(key: 'Backend/Toolbar/Show:title')}">
-        <f:comment>
-            Change as inline code when https://review.typo3.org/#/c/54212/ is merged.
-        </f:comment>
-        <f:if condition="{result.flattenedErrors}">
-            <f:then>
-                <nz:core.icon identifier="tx-notiz-icon-toolbar"
-                           alternativeMarkupIdentifier="inline"
-                           overlay="overlay-missing" />
-            </f:then>
-            <f:else>
-                <nz:core.icon identifier="tx-notiz-icon-toolbar"
-                           alternativeMarkupIdentifier="inline" />
-            </f:else>
-        </f:if>
+        <f:render partial="Backend/Toolbar/ToolbarIcon"
+                  section="Content"
+                  arguments="{result: result}" />
     </span>
 </f:section>
 

--- a/Resources/Public/JavaScript/Toolbar.js
+++ b/Resources/Public/JavaScript/Toolbar.js
@@ -111,7 +111,7 @@ define([
                     '<p class="dropdown-text text-danger">' + TYPO3.lang['notiz.toolbar.error.body'] + '</p>' +
                     '<hr />' +
                     '<p class="dropdown-text">' +
-                    '<a href="#" onclick="TYPO3.NotificationToolbar.menu.refresh();" title="' + refreshLabel + '">' +
+                    '<a href="javascript:void(0);" onclick="TYPO3.NotificationToolbar.menu.refresh();" title="' + refreshLabel + '">' +
                     '<span class="refresh-icon"></span>' + '&nbsp;' + refreshLabel +
                     '</a>' +
                     '</p>'

--- a/Resources/Public/JavaScript/Toolbar.js
+++ b/Resources/Public/JavaScript/Toolbar.js
@@ -19,8 +19,8 @@ define([
     };
 
     var menu = (function () {
-        var toolbarContainer = $(selector.toolbarContainer),
-            menuContainer = toolbarContainer.find(selector.menuContainer);
+        var toolbarContainer = $(selector.toolbarContainer);
+        var menuContainer = toolbarContainer.find(selector.menuContainer);
 
         return {
             container: menuContainer,
@@ -165,9 +165,9 @@ define([
      * Timer used for refreshing the toolbar.
      */
     var timer = (function () {
-        var instance = null,
-            defaultTick = 1000 * 60 * 5, // 5 minutes
-            tick = defaultTick;
+        var instance = null;
+        var defaultTick = 1000 * 60 * 5; // 5 minutes
+        var tick = defaultTick;
 
         return {
             reset: function () {

--- a/Resources/Public/JavaScript/Toolbar.js
+++ b/Resources/Public/JavaScript/Toolbar.js
@@ -28,7 +28,7 @@ define([
             content: function (content) {
                 menuContainer.html(content);
             },
-            
+
             show: function () {
                 toolbarContainer.addClass('open');
             },
@@ -47,31 +47,31 @@ define([
                             skipSessionUpdate: 1
                         },
                         type: 'post',
-                        cache: false,
-                        success: function (result) {
-                            // Display the new content of the toolbar.
-                            menu.content(result);
+                        cache: false
+                    })
+                    .done(function (result) {
+                        // Display the new content of the toolbar.
+                        menu.content(result);
 
-                            // Update the icon (can have an error overlay).
-                            icon.update(menu.container.find(selector.iconContainer).html());
+                        // Update the icon (can have an error overlay).
+                        icon.update(menu.container.find(selector.iconContainer).html());
 
-                            // Send a flash message to the user.
-                            var data = menu.data();
-                            message.new(data.type).send(data.message.title, data.message.body);
+                        // Send a flash message to the user.
+                        var data = menu.data();
+                        message.new(data.type).send(data.message.title, data.message.body);
 
-                            if (data.error) {
-                                timer.fastTick();
-                            } else {
-                                timer.defaultTick();
-                            }
-                        },
-                        error: menu.error,
-                        complete: function () {
-                            timer.launch();
+                        if (data.error) {
+                            timer.fastTick();
+                        } else {
+                            timer.defaultTick();
+                        }
+                    })
+                    .fail(menu.error)
+                    .always(function () {
+                        timer.launch();
 
-                            if (typeof callback !== 'undefined') {
-                                callback();
-                            }
+                        if (typeof callback !== 'undefined') {
+                            callback();
                         }
                     });
                 });
@@ -195,7 +195,7 @@ define([
         }
     })();
 
-    var message = (function() {
+    var message = (function () {
         var typeKey = 'notiz.toolbar.message_type';
 
         return {
@@ -221,7 +221,7 @@ define([
                         if (lastType === type) {
                             return;
                         }
-                        
+
                         if (type === 'error') {
                             Notification.error(title, body);
                         } else {

--- a/Resources/Public/JavaScript/Toolbar.js
+++ b/Resources/Public/JavaScript/Toolbar.js
@@ -1,0 +1,274 @@
+define([
+    'jquery',
+    'TYPO3/CMS/Backend/Icons',
+    'TYPO3/CMS/Backend/Notification',
+    'TYPO3/CMS/Backend/Storage'
+], function ($, Icons, Notification, Storage) {
+    'use strict';
+
+    var selector = {
+        toolbarContainer: '#cuyz-notiz-backend-toolbaritems-notificationstoolbaritem',
+        menuContainer: '.dropdown-menu',
+        toolbarIcon: '.toolbar-item-icon .t3js-icon',
+        /**
+         * @deprecated Must be removed when TYPO3 v7 is not supported anymore.
+         */
+        legacyToolbarIcon: '.dropdown-toggle span.icon',
+        dataContainer: '.t3js-notiz-data-container',
+        iconContainer: '.t3js-notiz-icon'
+    };
+
+    var menu = (function () {
+        var toolbarContainer = $(selector.toolbarContainer),
+            menuContainer = toolbarContainer.find(selector.menuContainer);
+
+        return {
+            container: menuContainer,
+
+            content: function (content) {
+                menuContainer.html(content);
+            },
+            
+            show: function () {
+                toolbarContainer.addClass('open');
+            },
+
+            /**
+             * Updates the content of the toolbar menu: it is fetched with an
+             * Ajax request.
+             */
+            update: function (callback) {
+                timer.reset();
+
+                loading.run(function () {
+                    $.ajax({
+                        url: TYPO3.settings.ajaxUrls['notiz_render_toolbar'],
+                        data: {
+                            skipSessionUpdate: 1
+                        },
+                        type: 'post',
+                        cache: false,
+                        success: function (result) {
+                            // Display the new content of the toolbar.
+                            menu.content(result);
+
+                            // Update the icon (can have an error overlay).
+                            icon.update(menu.container.find(selector.iconContainer).html());
+
+                            // Send a flash message to the user.
+                            var data = menu.data();
+                            message.new(data.type).send(data.message.title, data.message.body);
+
+                            if (data.error) {
+                                timer.fastTick();
+                            } else {
+                                timer.defaultTick();
+                            }
+                        },
+                        error: menu.error,
+                        complete: function () {
+                            timer.launch();
+
+                            if (typeof callback !== 'undefined') {
+                                callback();
+                            }
+                        }
+                    });
+                });
+            },
+
+            /**
+             * Fetches data from a hidden element in the menu container. These
+             * data are updated every time the toolbar is refreshed.
+             */
+            data: function () {
+                var container = menuContainer.find(selector.dataContainer);
+
+                return {
+                    error: !!container.data('error'),
+                    type: container.data('error') ? 'error' : 'success',
+                    message: {
+                        title: container.data('message-title'),
+                        body: container.data('message-body')
+                    }
+                }
+            },
+
+            /**
+             * If something went wrong when refreshing the toolbar, an error
+             * message is displayed.
+             */
+            error: function () {
+                timer.fastTick();
+
+                // Reset the icon with its initial value.
+                icon.update();
+
+                // Display some error messages and a refresh button.
+                var refreshLabel = TYPO3.lang['notiz.toolbar.error.refresh_label'];
+
+                menu.content(
+                    '<p class="dropdown-text text-danger">' + TYPO3.lang['notiz.toolbar.error.body'] + '</p>' +
+                    '<hr />' +
+                    '<p class="dropdown-text">' +
+                    '<a href="#" onclick="TYPO3.NotificationToolbar.menu.refresh();" title="' + refreshLabel + '">' +
+                    '<span class="refresh-icon"></span>' + '&nbsp;' + refreshLabel +
+                    '</a>' +
+                    '</p>'
+                );
+
+                // Urgh.
+                Icons.getIcon('actions-refresh', Icons.sizes.small, '', '', 'inline')
+                    .done(function (refreshIcon) {
+                        menu.container.find('.refresh-icon').replaceWith(refreshIcon);
+                    });
+            }
+        };
+    })();
+
+    var loading = {
+        run: function (callback) {
+            Icons.getIcon('spinner-circle-light', Icons.sizes.small).done(function (spinner) {
+                menu.content('<p class="text-center">' + spinner + '</p>');
+                icon.update(spinner);
+
+                callback();
+            });
+        }
+    };
+
+    var icon = (function () {
+        var container = function () {
+            var element = $(selector.toolbarIcon, selector.toolbarContainer);
+
+            if (element.length === 0) {
+                element = $(selector.legacyToolbarIcon, selector.toolbarContainer);
+            }
+
+            return element;
+        };
+
+        /**
+         * Initial icon of the toolbar. We keep it in memory in case something
+         * goes wrong, in which case it will be re-used.
+         */
+        var backupIcon = container().html();
+
+        return {
+            update: function (newIcon) {
+                container().html(newIcon || backupIcon);
+            }
+        }
+    })();
+
+    /**
+     * Timer used for refreshing the toolbar.
+     */
+    var timer = (function () {
+        var instance = null,
+            defaultTick = 1000 * 60 * 5, // 5 minutes
+            tick = defaultTick;
+
+        return {
+            reset: function () {
+                if (instance !== null) {
+                    clearTimeout(instance);
+                    instance = null;
+                }
+            },
+            launch: function () {
+                instance = setTimeout(menu.update, tick);
+            },
+            tick: function (newTick) {
+                tick = 1000 * newTick
+            },
+            defaultTick: function () {
+                tick = defaultTick;
+            },
+            /**
+             * Speeds up the tick of the timer to increase chance to get a valid
+             * toolbar faster.
+             */
+            fastTick: function () {
+                tick = 1000 * 30; // 30 seconds
+            }
+        }
+    })();
+
+    var message = (function() {
+        var typeKey = 'notiz.toolbar.message_type';
+
+        return {
+            new: function (type) {
+                return {
+                    /**
+                     * Displays a flash message for the user, telling him/her if
+                     * notifications are enabled or disabled.
+                     */
+                    send: function (title, body) {
+                        if (!title && !body) {
+                            return;
+                        }
+
+                        var lastType = Storage.Persistent.isset(typeKey)
+                            ? Storage.Persistent.get(typeKey)
+                            : null;
+
+                        /*
+                         * We display the message only if it was not displayed
+                         * previously.
+                         */
+                        if (lastType === type) {
+                            return;
+                        }
+                        
+                        if (type === 'error') {
+                            Notification.error(title, body);
+                        } else {
+                            Notification.success(title, body, 10);
+                        }
+
+                        Storage.Persistent.set(typeKey, type);
+                    }
+                }
+            }
+        }
+    })();
+
+    try {
+        /**
+         * Registers the menu update as an event for the whole TYPO3 toolbar.
+         */
+        TYPO3.Backend.Topbar.Toolbar.registerEvent(menu.update);
+    } catch (e) {
+        /**
+         * @deprecated Must be removed when TYPO3 v7 is not supported anymore.
+         *
+         * Steps to follow:
+         * - Add `TYPO3/CMS/Backend/Viewport` as dependency in the RequireJS
+         *   section of this file.
+         * - Use the following statement instead of this try/catch block:
+         *   `Viewport.Topbar.Toolbar.registerEvent(menu.update);`
+         */
+        $(menu.update);
+    }
+
+    /**
+     * Public API of this module.
+     */
+    return TYPO3.NotificationToolbar = {
+        menu: {
+            update: menu.update,
+
+            /**
+             * Same as update, but at the end of the process the toolbar menu is
+             * displayed.
+             */
+            refresh: function () {
+                menu.update(function () {
+                    menu.show();
+                });
+            }
+        }
+    };
+});


### PR DESCRIPTION
A periodic asynchronous refresh has been added to the notification
toolbar. These Ajax requests will reload notification information every
5 minutes in normal time, and every 30 seconds if an error occurred.

Buttons have been added in the toolbar, allowing a manual refresh.

One thing to note is that the first rendering of the toolbar (done
during the TYPO3 backend rendering) does not contain information about
existing notifications anymore (they will be fetched asynchronously).
This can slightly improve performance when a lot of notifications were
to be listed.

---

Checklist before merging:

- [ ]  German translation has been added