### PR TITLE
[BUGFIX] Set the default value of `custom_bot` column to `1`

### DIFF
--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
@@ -86,7 +86,7 @@ class EntitySlackTcaWriter extends EntityTcaWriter
                     'displayCond' => 'USER:' . $this->getNotificationTcaServiceClass() . '->hasDefinedBot',
                     'config' => [
                         'type' => 'check',
-                        'default' => 0,
+                        'default' => 1,
                     ],
                 ],
 


### PR DESCRIPTION
When there are no configured Slack bot, the `custom_bot` checkbox does
not appear and is set to `false`. The custom bot could not be detected.