### PR TITLE
[TASK] Make exception return type consistent

### DIFF
--- a/Classes/Core/Exception/ClassNotFoundException.php
+++ b/Classes/Core/Exception/ClassNotFoundException.php
@@ -42,7 +42,7 @@ class ClassNotFoundException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function definitionSourceClassNotFound($className)
     {
@@ -55,7 +55,7 @@ class ClassNotFoundException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function definitionProcessorClassNotFound($className)
     {
@@ -68,7 +68,7 @@ class ClassNotFoundException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function eventClassNotFound($className)
     {
@@ -82,7 +82,7 @@ class ClassNotFoundException extends NotizException
     /**
      * @param string $propertyType
      * @param string $identifier
-     * @return static
+     * @return self
      */
     public static function tagServicePropertyClassNotFound($propertyType, $identifier)
     {
@@ -95,7 +95,7 @@ class ClassNotFoundException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function notificationClassNotFound($className)
     {
@@ -109,7 +109,7 @@ class ClassNotFoundException extends NotizException
     /**
      * @param string $notificationClassName
      * @param string $processorClassName
-     * @return static
+     * @return self
      */
     public static function notificationProcessorClassNotFound($notificationClassName, $processorClassName)
     {
@@ -122,7 +122,7 @@ class ClassNotFoundException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function notificationSettingsClassNotFound($className)
     {
@@ -136,7 +136,7 @@ class ClassNotFoundException extends NotizException
     /**
      * @param string $interface
      * @param Hook $hook
-     * @return static
+     * @return self
      */
     public static function eventHookInterfaceNotFound($interface, Hook $hook)
     {
@@ -152,7 +152,7 @@ class ClassNotFoundException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function eventConfigurationFlexFormProviderClassNotFound($className)
     {
@@ -165,7 +165,7 @@ class ClassNotFoundException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function channelSettingsClassNotFound($className)
     {

--- a/Classes/Core/Exception/DuplicateEntryException.php
+++ b/Classes/Core/Exception/DuplicateEntryException.php
@@ -33,7 +33,7 @@ class DuplicateEntryException extends NotizException
     /**
      * @param string $identifier
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function definitionSourceDuplication($identifier, $className)
     {
@@ -47,7 +47,7 @@ class DuplicateEntryException extends NotizException
     /**
      * @param string $identifier
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function definitionProcessorDuplication($identifier, $className)
     {
@@ -62,7 +62,7 @@ class DuplicateEntryException extends NotizException
      * @param string $name
      * @param string $eventClassName
      * @param string $propertyType
-     * @return static
+     * @return self
      */
     public static function propertyEntryDuplication($name, $eventClassName, $propertyType)
     {
@@ -77,7 +77,7 @@ class DuplicateEntryException extends NotizException
      * @param string $identifier
      * @param string $propertyType
      * @param string $assignedPropertyType
-     * @return static
+     * @return self
      */
     public static function tagServiceIdentifierDuplication($identifier, $propertyType, $assignedPropertyType)
     {
@@ -90,7 +90,7 @@ class DuplicateEntryException extends NotizException
 
     /**
      * @param string $name
-     * @return static
+     * @return self
      */
     public static function slotContainerDuplication($name)
     {
@@ -104,7 +104,7 @@ class DuplicateEntryException extends NotizException
     /**
      * @param string $marker
      * @param string $slot
-     * @return static
+     * @return self
      */
     public static function markerAlreadyDefined($marker, $slot)
     {

--- a/Classes/Core/Exception/EntryNotFoundException.php
+++ b/Classes/Core/Exception/EntryNotFoundException.php
@@ -51,7 +51,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $identifier
-     * @return static
+     * @return self
      */
     public static function definitionSourceNotFound($identifier)
     {
@@ -64,7 +64,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $identifier
-     * @return static
+     * @return self
      */
     public static function definitionProcessorNotFound($identifier)
     {
@@ -77,7 +77,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $identifier
-     * @return static
+     * @return self
      */
     public static function definitionEventGroupNotFound($identifier)
     {
@@ -90,7 +90,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $identifier
-     * @return static
+     * @return self
      */
     public static function definitionEventNotFound($identifier)
     {
@@ -103,7 +103,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $fullIdentifier
-     * @return static
+     * @return self
      */
     public static function definitionEventFullIdentifierNotFound($fullIdentifier)
     {
@@ -116,7 +116,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $identifier
-     * @return static
+     * @return self
      */
     public static function definitionNotificationNotFound($identifier)
     {
@@ -129,7 +129,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $identifier
-     * @return static
+     * @return self
      */
     public static function entityEmailViewLayoutNotFound($identifier)
     {
@@ -145,7 +145,7 @@ class EntryNotFoundException extends NotizException
      * @param string $eventClassName
      * @param string $propertyType
      * @param object $object
-     * @return static
+     * @return self
      */
     public static function propertyEntryNotFound($name, $eventClassName, $propertyType, $object)
     {
@@ -158,7 +158,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $key
-     * @return static
+     * @return self
      */
     public static function extensionConfigurationEntryNotFound($key)
     {
@@ -171,7 +171,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $key
-     * @return static
+     * @return self
      */
     public static function eventRunnerEntryNotFound($key)
     {
@@ -184,7 +184,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param array $allowedTypes
-     * @return static
+     * @return self
      */
     public static function eventConnectionTypeMissing(array $allowedTypes)
     {
@@ -197,7 +197,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $botIdentifier
-     * @return static
+     * @return self
      */
     public static function entitySlackBotNotFound($botIdentifier)
     {
@@ -210,7 +210,7 @@ class EntryNotFoundException extends NotizException
 
     /**
      * @param string $identifier
-     * @return static
+     * @return self
      */
     public static function entitySlackChannelDefinitionNotFound($identifier)
     {

--- a/Classes/Core/Exception/FileNotFoundException.php
+++ b/Classes/Core/Exception/FileNotFoundException.php
@@ -22,7 +22,7 @@ class FileNotFoundException extends NotizException
 
     /**
      * @param string $filePath
-     * @return static
+     * @return self
      */
     public static function definitionSourceTypoScriptFileNotFound($filePath)
     {

--- a/Classes/Core/Exception/InvalidClassException.php
+++ b/Classes/Core/Exception/InvalidClassException.php
@@ -51,7 +51,7 @@ class InvalidClassException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function definitionSourceHasMissingInterface($className)
     {
@@ -64,7 +64,7 @@ class InvalidClassException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function definitionProcessorHasMissingInterface($className)
     {
@@ -77,7 +77,7 @@ class InvalidClassException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function eventHasMissingInterface($className)
     {
@@ -91,7 +91,7 @@ class InvalidClassException extends NotizException
     /**
      * @param string $propertyType
      * @param string $identifier
-     * @return static
+     * @return self
      */
     public static function tagServicePropertyWrongParent($propertyType, $identifier)
     {
@@ -104,7 +104,7 @@ class InvalidClassException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function notificationMissingInterface($className)
     {
@@ -118,7 +118,7 @@ class InvalidClassException extends NotizException
     /**
      * @param string $notificationClassName
      * @param string $processorClassName
-     * @return static
+     * @return self
      */
     public static function notificationProcessorWrongParent($notificationClassName, $processorClassName)
     {
@@ -131,7 +131,7 @@ class InvalidClassException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function notificationSettingsMissingInterface($className)
     {
@@ -144,7 +144,7 @@ class InvalidClassException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function eventConfigurationFlexFormProviderMissingInterface($className)
     {
@@ -157,7 +157,7 @@ class InvalidClassException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function channelSettingsMissingInterface($className)
     {
@@ -170,7 +170,7 @@ class InvalidClassException extends NotizException
 
     /**
      * @param string $className
-     * @return static
+     * @return self
      */
     public static function eventPropertyBuilderMissingInterface($className)
     {

--- a/Classes/Core/Exception/InvalidDefinitionException.php
+++ b/Classes/Core/Exception/InvalidDefinitionException.php
@@ -23,7 +23,7 @@ class InvalidDefinitionException extends NotizException
     const DEFINITION_ERROR_NO_ACCESS = 'The definition contains errors, it is not accessible. Please use method `%s::getValidationResult()`.';
 
     /**
-     * @return static
+     * @return self
      */
     public static function definitionErrorNoAccess()
     {

--- a/Classes/Core/Exception/InvalidTypeException.php
+++ b/Classes/Core/Exception/InvalidTypeException.php
@@ -38,7 +38,7 @@ class InvalidTypeException extends NotizException
 
     /**
      * @param mixed $notifications
-     * @return static
+     * @return self
      */
     public static function notificationContainerArrayInvalidType($notifications)
     {
@@ -53,7 +53,7 @@ class InvalidTypeException extends NotizException
      * @param string $key
      * @param mixed $notification
      * @param NotificationDefinition $notificationDefinition
-     * @return static
+     * @return self
      */
     public static function notificationContainerEntryInvalidType($key, $notification, NotificationDefinition $notificationDefinition)
     {
@@ -70,7 +70,7 @@ class InvalidTypeException extends NotizException
 
     /**
      * @param string $channelClassName
-     * @return static
+     * @return self
      */
     public static function channelSupportedNotificationsWrongType($channelClassName)
     {
@@ -84,7 +84,7 @@ class InvalidTypeException extends NotizException
     /**
      * @param string $channelClassName
      * @param array $invalidListEntries
-     * @return static
+     * @return self
      */
     public static function channelSupportedNotificationsInvalidListEntries($channelClassName, array $invalidListEntries)
     {
@@ -101,7 +101,7 @@ class InvalidTypeException extends NotizException
     /**
      * @param Channel                   $channel
      * @param NotificationDefinition $notification
-     * @return static
+     * @return self
      */
     public static function channelUnsupportedNotificationDispatched(Channel $channel, NotificationDefinition $notification)
     {
@@ -117,7 +117,7 @@ class InvalidTypeException extends NotizException
 
     /**
      * @param mixed $value
-     * @return static
+     * @return self
      */
     public static function definitionValidationWrongType($value)
     {
@@ -134,7 +134,7 @@ class InvalidTypeException extends NotizException
     /**
      * @param string $type
      * @param array $allowedTypes
-     * @return static
+     * @return self
      */
     public static function eventConnectionWrongType($type, array $allowedTypes)
     {

--- a/Classes/Core/Exception/NotImplementedException.php
+++ b/Classes/Core/Exception/NotImplementedException.php
@@ -22,7 +22,7 @@ class NotImplementedException extends NotizException
 
     /**
      * @param string $methodName
-     * @return static
+     * @return self
      */
     public static function tcaServiceNotificationIdentifierMissing($methodName)
     {

--- a/Classes/Core/Exception/PropertyNotAccessibleException.php
+++ b/Classes/Core/Exception/PropertyNotAccessibleException.php
@@ -25,7 +25,7 @@ class PropertyNotAccessibleException extends NotizException
 
     /**
      * @param PropertyEntry $propertyEntry
-     * @return static
+     * @return self
      */
     public static function propertyEntryValueNotAccessible(PropertyEntry $propertyEntry)
     {

--- a/Classes/Core/Exception/WrongFormatException.php
+++ b/Classes/Core/Exception/WrongFormatException.php
@@ -31,7 +31,7 @@ class WrongFormatException extends NotizException
      * @param string $identifier
      * @param string $suggestion
      * @param string $rules
-     * @return static
+     * @return self
      */
     public static function tagServiceIdentifierWrongFormat($propertyType, $identifier, $suggestion, $rules)
     {
@@ -45,7 +45,7 @@ class WrongFormatException extends NotizException
     /**
      * @param string $methodName
      * @param Hook $hook
-     * @return static
+     * @return self
      */
     public static function eventHookMethodNameWrongFormat($methodName, Hook $hook)
     {
@@ -58,7 +58,7 @@ class WrongFormatException extends NotizException
 
     /**
      * @param string $name
-     * @return static
+     * @return self
      */
     public static function slotNameWrongFormat($name)
     {


### PR DESCRIPTION
Using `static` was not correct and would make IDE not understand the
type of the exception in all situations.