### PR TITLE
[TASK] Separate definition error handling in TCA

### DIFF
--- a/Classes/Backend/FormEngine/DataProvider/DefaultEventFromGet.php
+++ b/Classes/Backend/FormEngine/DataProvider/DefaultEventFromGet.php
@@ -36,7 +36,7 @@ class DefaultEventFromGet implements FormDataProviderInterface
 
     /**
      * @param array $result
-     * @return array Result
+     * @return array
      */
     public function addData(array $result)
     {

--- a/Classes/Backend/FormEngine/DataProvider/DefinitionError.php
+++ b/Classes/Backend/FormEngine/DataProvider/DefinitionError.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Backend\FormEngine\DataProvider;
+
+use CuyZ\Notiz\Core\Definition\DefinitionService;
+use CuyZ\Notiz\Core\Notification\TCA\EntityTcaWriter;
+use CuyZ\Notiz\Service\Container;
+use CuyZ\Notiz\Service\ViewService;
+use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+
+/**
+ * If a definition error is found, the whole TCA is modified for entity
+ * notifications; instead of normal fields, an error message is shown.
+ */
+class DefinitionError implements FormDataProviderInterface
+{
+    /**
+     * @var DefinitionService
+     */
+    private $definitionService;
+
+    /**
+     * @var ViewService
+     */
+    private $viewService;
+
+    /**
+     * Manual dependency injection.
+     */
+    public function __construct()
+    {
+        $this->definitionService = Container::get(DefinitionService::class);
+        $this->viewService = Container::get(ViewService::class);
+    }
+
+    /**
+     * @param array $result
+     * @return array
+     */
+    public function addData(array $result)
+    {
+        $tableName = $result['tableName'];
+
+        if (!isset($GLOBALS['TCA'][$tableName]['ctrl'][EntityTcaWriter::ENTITY_NOTIFICATION])) {
+            return $result;
+        }
+
+        if ($this->definitionService->getValidationResult()->hasErrors()) {
+            ArrayUtility::mergeRecursiveWithOverrule($GLOBALS['TCA'][$tableName], $this->getDefinitionErrorTca());
+        }
+
+        return $result;
+    }
+
+    /**
+     * @return array
+     */
+    private function getDefinitionErrorTca()
+    {
+        return [
+            'types' => [
+                '0' => [
+                    'showitem' => 'definition_error_message',
+                ],
+            ],
+            'columns' => [
+                'definition_error_message' => [
+                    'config' => [
+                        'type' => 'user',
+                        'userFunc' => self::class . '->getDefinitionErrorMessage',
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function getDefinitionErrorMessage()
+    {
+        $view = $this->viewService->getStandaloneView('Backend/TCA/DefinitionErrorMessage');
+
+        $view->assign('result', $this->definitionService->getValidationResult());
+
+        return $view->render();
+    }
+}

--- a/Classes/Core/Notification/Service/NotificationTcaService.php
+++ b/Classes/Core/Notification/Service/NotificationTcaService.php
@@ -74,33 +74,6 @@ abstract class NotificationTcaService implements SingletonInterface
     }
 
     /**
-     * @param array $parameters
-     * @return bool
-     */
-    public function definitionContainsErrors(array $parameters)
-    {
-        $result = !$this->definitionHasErrors();
-
-        if (in_array('inverted', $parameters['conditionParameters'])) {
-            $result = !$result;
-        }
-
-        return $result;
-    }
-
-    /**
-     * @return string
-     */
-    public function getErrorMessage()
-    {
-        $view = $this->viewService->getStandaloneView('Backend/TCA/DefinitionErrorMessage');
-
-        $view->assign('result', $this->definitionService->getValidationResult());
-
-        return $view->render();
-    }
-
-    /**
      * Loads all available events and stores them as an array to be used in the
      * TCA.
      *

--- a/Classes/Service/Extension/LocalConfigurationService.php
+++ b/Classes/Service/Extension/LocalConfigurationService.php
@@ -17,6 +17,7 @@
 namespace CuyZ\Notiz\Service\Extension;
 
 use CuyZ\Notiz\Backend\FormEngine\DataProvider\DefaultEventFromGet;
+use CuyZ\Notiz\Backend\FormEngine\DataProvider\DefinitionError;
 use CuyZ\Notiz\Backend\ToolBarItems\NotificationsToolbarItem;
 use CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder;
 use CuyZ\Notiz\Core\Support\NotizConstants;
@@ -28,6 +29,7 @@ use CuyZ\Notiz\Service\Hook\NotificationFlexFormProcessor;
 use CuyZ\Notiz\Service\Traits\SelfInstantiateTrait;
 use TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRecordOverrideValues;
 use TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRowDefaultValues;
+use TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca;
 use TYPO3\CMS\Core\Cache\Backend\FileBackend;
 use TYPO3\CMS\Core\Cache\Frontend\VariableFrontend;
 use TYPO3\CMS\Core\Database\TableConfigurationPostProcessingHookInterface;
@@ -251,5 +253,8 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
 
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DefaultEventFromGet::class] = $databaseRowDefaultValues;
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DatabaseRecordOverrideValues::class]['depends'][] = DefaultEventFromGet::class;
+
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DefinitionError::class] = [];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][InitializeProcessedTca::class]['depends'][] = DefinitionError::class;
     }
 }


### PR DESCRIPTION
Changes the way the definition error is handled within entity
notifications.

The old way consisted in adding display conditions to every field to
check if the definition contains error.

Now, a data provider does the same job, and replaces the whole TCA if an
error is found.