### PR TITLE
[BUGFIX] Move event configuration TCA to graceful data provider

### DIFF
--- a/Classes/Backend/FormEngine/DataProvider/EventConfigurationProvider.php
+++ b/Classes/Backend/FormEngine/DataProvider/EventConfigurationProvider.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Backend\FormEngine\DataProvider;
+
+use CuyZ\Notiz\Core\Notification\Service\LegacyNotificationTcaService;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
+
+/**
+ * Builds the TCA array for the event configuration.
+ *
+ * It is a FlexForm field, with as many definition sheets as there are events
+ * using FlexForm. Display conditions are dynamically assigned to show the
+ * correct definition depending on the selected event.
+ */
+class EventConfigurationProvider extends GracefulProvider
+{
+    const COLUMN = '__eventConfiguration';
+
+    /**
+     * @param array $result
+     * @return array
+     */
+    public function process(array $result)
+    {
+        $tableName = $result['tableName'];
+
+        if (!isset($GLOBALS['TCA'][$tableName]['ctrl'][self::COLUMN])) {
+            return $result;
+        }
+
+        $columnName = $GLOBALS['TCA'][$tableName]['ctrl'][self::COLUMN];
+
+        if (!isset($GLOBALS['TCA'][$tableName]['columns'][$columnName])) {
+            return $result;
+        }
+
+        $this->fillEventConfigurationTca($tableName, $columnName);
+
+        return $result;
+    }
+
+    /**
+     * @param string $tableName
+     * @param string $columnName
+     */
+    private function fillEventConfigurationTca($tableName, $columnName)
+    {
+        $flexFormDs = [];
+        $displayConditions = [];
+
+        foreach ($this->definitionService->getDefinition()->getEvents() as $event) {
+            $provider = $event->getConfiguration()->getFlexFormProvider();
+
+            if ($provider->hasFlexForm()) {
+                $identifier = $event->getFullIdentifier();
+
+                $flexFormDs[$identifier] = $provider->getFlexFormValue();
+                $displayConditions[] = $identifier;
+            }
+        }
+
+        // If no definition is found, the field is not shown at all.
+        if (empty($flexFormDs)) {
+            $GLOBALS['TCA'][$tableName]['columns'][$columnName]['config'] = ['type' => 'passthrough'];
+        }
+
+        /**
+         * @deprecated Value can be empty when TYPO3 v7 is not supported anymore.
+         */
+        $flexFormDs['default'] = 'FILE:EXT:notiz/Configuration/FlexForm/Event/DefaultEventFlexForm.xml';
+
+        $GLOBALS['TCA'][$tableName]['columns'][$columnName]['config']['ds'] = $flexFormDs;
+
+        $GLOBALS['TCA'][$tableName]['columns'][$columnName]['displayCond'] = version_compare(VersionNumberUtility::getCurrentTypo3Version(), '8.0.0', '<')
+            ? 'USER:' . LegacyNotificationTcaService::class . '->displayEventFlexForm:' . $tableName . ':' . implode(',', $displayConditions)
+            : 'FIELD:event:IN:' . implode(',', $displayConditions);
+    }
+}

--- a/Classes/Backend/FormEngine/DataProvider/GracefulProvider.php
+++ b/Classes/Backend/FormEngine/DataProvider/GracefulProvider.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Backend\FormEngine\DataProvider;
+
+use CuyZ\Notiz\Core\Definition\DefinitionService;
+use CuyZ\Notiz\Service\Container;
+use CuyZ\Notiz\Service\ViewService;
+use Exception;
+use Throwable;
+use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
+use TYPO3\CMS\Core\Utility\ArrayUtility;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * This provider must be used to complete the TCA of entity notifications, for
+ * parts that require complex logic that may be failing under certain
+ * circumstances (meaning an exception can be thrown for any reason).
+ *
+ * The goal is to apply this kind of logic after the TCA tree has been generated
+ * and put in cache, because if something fails it would crash for the whole
+ * backend.
+ *
+ * Using this graceful provider, if something breaks during the execution of the
+ * child provider, the error is caught in order to prevent showing the fatal
+ * error to the user; instead, a message is displayed with some information about
+ * the exception.
+ */
+abstract class GracefulProvider implements FormDataProviderInterface
+{
+    /**
+     * @var DefinitionService
+     */
+    protected $definitionService;
+
+    /**
+     * @var ViewService
+     */
+    private $viewService;
+
+    /**
+     * Manual dependency injection.
+     */
+    public function __construct()
+    {
+        $this->definitionService = Container::get(DefinitionService::class);
+        $this->viewService = Container::get(ViewService::class);
+    }
+
+    /**
+     * @param array $result
+     * @return array
+     * @throws Throwable
+     */
+    final public function addData(array $result)
+    {
+        if ($this->definitionService->getValidationResult()->hasErrors()) {
+            return $result;
+        }
+
+        try {
+            return $this->process($result);
+        } catch (Throwable $exception) {
+        } catch (Exception $exception) {
+            // @PHP7
+        }
+
+        if ($exception) {
+            if (GeneralUtility::_GET('showException')) {
+                throw $exception;
+            }
+
+            ArrayUtility::mergeRecursiveWithOverrule(
+                $GLOBALS['TCA'][$result['tableName']],
+                $this->getDefinitionErrorTca($exception)
+            );
+        }
+
+        return $result;
+    }
+
+    /**
+     * @param array $result
+     * @return array
+     */
+    abstract protected function process(array $result);
+
+    /**
+     * @param Throwable $exception
+     * @return array
+     */
+    private function getDefinitionErrorTca($exception)
+    {
+        return [
+            'types' => [
+                '0' => [
+                    'showitem' => 'error_message',
+                ],
+            ],
+            'columns' => [
+                'error_message' => [
+                    'config' => [
+                        'type' => 'user',
+                        'userFunc' => static::class . '->getErrorMessage',
+                        'parameters' => [
+                            'exception' => $exception,
+                        ]
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array $arguments
+     * @return string
+     */
+    public function getErrorMessage($arguments)
+    {
+        $view = $this->viewService->getStandaloneView('Backend/TCA/ErrorMessage');
+
+        $frameSrc = GeneralUtility::getIndpEnv('REQUEST_URI') . '&showException=1';
+
+        $view->assign('frameSrc', $frameSrc);
+        $view->assign('exception', $arguments['parameters']['exception']);
+
+        return $view->render();
+    }
+}

--- a/Classes/Service/Extension/LocalConfigurationService.php
+++ b/Classes/Service/Extension/LocalConfigurationService.php
@@ -18,6 +18,7 @@ namespace CuyZ\Notiz\Service\Extension;
 
 use CuyZ\Notiz\Backend\FormEngine\DataProvider\DefaultEventFromGet;
 use CuyZ\Notiz\Backend\FormEngine\DataProvider\DefinitionError;
+use CuyZ\Notiz\Backend\FormEngine\DataProvider\EventConfigurationProvider;
 use CuyZ\Notiz\Backend\ToolBarItems\NotificationsToolbarItem;
 use CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder;
 use CuyZ\Notiz\Core\Support\NotizConstants;
@@ -254,7 +255,19 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DefaultEventFromGet::class] = $databaseRowDefaultValues;
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DatabaseRecordOverrideValues::class]['depends'][] = DefaultEventFromGet::class;
 
+        /*
+         * A data provider will be used to detect any definition error, in which
+         * case an error message is shown to the user trying to create/edit an
+         * entity notification.
+         */
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DefinitionError::class] = [];
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][InitializeProcessedTca::class]['depends'][] = DefinitionError::class;
+
+        /*
+         * A data provider is used to dynamically configure the event
+         * configuration fields, that depends on the definition.
+         */
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][EventConfigurationProvider::class] = [];
+        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][InitializeProcessedTca::class]['depends'][] = EventConfigurationProvider::class;
     }
 }

--- a/Configuration/FlexForm/Event/DefaultEventFlexForm.xml
+++ b/Configuration/FlexForm/Event/DefaultEventFlexForm.xml
@@ -3,7 +3,7 @@
         <sDEF>
             <ROOT>
                 <TCEforms>
-                    <sheetTitle>Default event FlexForm</sheetTitle>
+                    <sheetTitle>Deprecated - Must be removed when TYPO3 v7 is not supported anymore.</sheetTitle>
                 </TCEforms>
                 <type>array</type>
                 <el>

--- a/Resources/Private/Language/Backend/TCA/Global.xlf
+++ b/Resources/Private/Language/Backend/TCA/Global.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="en">
+        <header/>
+        <body>
+
+            <trans-unit id="exception_occurred.title">
+                <source>Configuration error</source>
+            </trans-unit>
+            <trans-unit id="exception_occurred.body">
+                <source><![CDATA[
+                An error occurred, the notification can not be edited.
+
+                If the problem persists, contact your administrator.
+                ]]></source>
+            </trans-unit>
+
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Language/Backend/TCA/fr.Global.xlf
+++ b/Resources/Private/Language/Backend/TCA/fr.Global.xlf
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="fr">
+        <header/>
+        <body>
+
+            <trans-unit id="exception_occurred.title">
+                <target>Erreur de configuration</target>
+            </trans-unit>
+            <trans-unit id="exception_occurred.body">
+                <target><![CDATA[
+                Une erreur est survenue, la notification ne peut pas être éditée.
+
+                Si le problème persiste, contactez votre administrateur.
+                ]]></target>
+            </trans-unit>
+
+        </body>
+    </file>
+</xliff>

--- a/Resources/Private/Templates/Backend/TCA/ErrorMessage.html
+++ b/Resources/Private/Templates/Backend/TCA/ErrorMessage.html
@@ -1,0 +1,16 @@
+{namespace core=TYPO3\CMS\Core\ViewHelpers}
+{namespace nz=CuyZ\Notiz\ViewHelpers}
+
+<f:be.infobox title="{nz:t(key: 'Backend/TCA/Global:exception_occurred.title')}" state="2">
+    <p>
+        <nz:t key="Backend/TCA/Global:exception_occurred.body" wrapLines="1" />
+    </p>
+
+    <f:if condition="{nz:backend.module.hasAccess(module: 'Administration')}">
+        <hr />
+
+        <f:render partial="Backend/ExceptionDetails"
+                  section="ExceptionDetails"
+                  arguments="{exception: exception, frameSrc: frameSrc}" />
+    </f:if>
+</f:be.infobox>


### PR DESCRIPTION
Prevents a crash of the whole TYPO3 backend under certain circumstances.