### PR TITLE
[FEATURE] Introduce simple definition file registration

### DIFF
--- a/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
+++ b/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
@@ -70,17 +70,17 @@ class DefaultDefinitionComponents implements SingletonInterface
         );
 
         // Default channels.
-        $typoScriptDefinitionSource->addTypoScriptFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Channel/Channels.Default.typoscript');
+        $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Channel/Channels.Default.typoscript');
 
         // Default notifications.
-        $typoScriptDefinitionSource->addTypoScriptFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Notification/Notifications.typoscript');
+        $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Notification/Notifications.typoscript');
 
         // TYPO3 events can be enabled/disabled in the extension configuration.
         if ($this->extensionConfigurationService->getConfigurationValue('events.typo3')) {
-            $typoScriptDefinitionSource->addTypoScriptFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.TYPO3.typoscript');
+            $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.TYPO3.typoscript');
 
             if (ExtensionManagementUtility::isLoaded('scheduler')) {
-                $typoScriptDefinitionSource->addTypoScriptFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Scheduler.typoscript');
+                $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Scheduler.typoscript');
             }
         }
 
@@ -88,7 +88,7 @@ class DefaultDefinitionComponents implements SingletonInterface
         if (ExtensionManagementUtility::isLoaded('form')
             && version_compare(VersionNumberUtility::getCurrentTypo3Version(), '8.0.0', '>=')
         ) {
-            $typoScriptDefinitionSource->addTypoScriptFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Form.typoscript');
+            $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Form.typoscript');
         }
     }
 }

--- a/Classes/Domain/Definition/Builder/Component/Source/FileDefinitionSource.php
+++ b/Classes/Domain/Definition/Builder/Component/Source/FileDefinitionSource.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Domain\Definition\Builder\Component\Source;
+
+use CuyZ\Notiz\Core\Definition\Builder\Component\Source\DefinitionSource;
+use CuyZ\Notiz\Core\Exception\FileNotFoundException;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Abstraction layer to ease registration of files containing definition.
+ *
+ * It enables automatic import of files:
+ *
+ * @see \CuyZ\Notiz\Domain\Definition\Builder\Component\Source\FileDefinitionSource::includeConfiguredSources
+ */
+abstract class FileDefinitionSource implements DefinitionSource, SingletonInterface
+{
+    /**
+     * @var array
+     */
+    protected $filePaths = [];
+
+    /**
+     * When the class is initialized, configured files are automatically
+     * included.
+     */
+    public function initializeObject()
+    {
+        $this->includeConfiguredSources();
+    }
+
+    /**
+     * Registers a path to a file that should contain definition for the API.
+     *
+     * @param string $path
+     * @return $this
+     *
+     * @throws FileNotFoundException
+     */
+    public function addFilePath($path)
+    {
+        if (isset($this->filePaths[$path])) {
+            return $this;
+        }
+
+        $absolutePath = GeneralUtility::getFileAbsFileName($path);
+
+        if (false === file_exists($absolutePath)) {
+            throw FileNotFoundException::definitionSourceTypoScriptFileNotFound($path);
+        }
+
+        $this->filePaths[$path] = $absolutePath;
+
+        return $this;
+    }
+
+    /**
+     * This will automatically register paths to TypoScript files that were
+     * registered inside `ext_localconf.php` files:
+     *
+     * ```
+     * $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['NotiZ']['Definition']['Source'][\MyVendor\MyExtension\Domain\Definition\Source\MyFileDefinitionSource::class][]
+     *     = 'EXT:my_extension/Configuration/Foo/my_definition.foo'
+     * ```
+     */
+    private function includeConfiguredSources()
+    {
+        // @PHP7
+        $configuredSources = isset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['NotiZ']['Definition']['Source'][static::class])
+            ? $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['NotiZ']['Definition']['Source'][static::class]
+            : [];
+
+        foreach ($configuredSources as $configuredSource) {
+            $this->addFilePath((string)$configuredSource);
+        }
+    }
+}

--- a/Classes/Domain/Definition/Builder/Component/Source/TypoScriptDefinitionSource.php
+++ b/Classes/Domain/Definition/Builder/Component/Source/TypoScriptDefinitionSource.php
@@ -16,11 +16,8 @@
 
 namespace CuyZ\Notiz\Domain\Definition\Builder\Component\Source;
 
-use CuyZ\Notiz\Core\Definition\Builder\Component\Source\DefinitionSource;
-use CuyZ\Notiz\Core\Exception\FileNotFoundException;
 use CuyZ\Notiz\Core\Support\NotizConstants;
 use Romm\ConfigurationObject\ConfigurationObjectInstance;
-use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\TypoScript\Parser\TypoScriptParser;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Extbase\Service\TypoScriptService;
@@ -29,8 +26,22 @@ use TYPO3\CMS\Extbase\Service\TypoScriptService;
  * This definition source component is used to fetch a definition array from
  * TypoScript files.
  *
- * You can register your own TypoScript definition file in a component
- * registration service (see example below).
+ * Simple TypoScript file registration
+ * -----------------------------------
+ *
+ * To add a TypoScript source file you can add the following line in the
+ * `ext_localconf.php` file of your extension:
+ *
+ * ```
+ * $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['NotiZ']['Definition']['Source'][\CuyZ\Notiz\Domain\Definition\Builder\Component\Source\TypoScriptDefinitionSource::class][]
+ *     = 'EXT:notiz_example/Configuration/TypoScript/Shop.typoscript';
+ * ```
+ *
+ * Advanced TypoScript file registration
+ * -------------------------------------
+ *
+ * In some cases you may need more complex logic to register files; you can then
+ * use a definition component service (see example below).
  *
  * To know how to register a new component:
  *
@@ -41,21 +52,16 @@ use TYPO3\CMS\Extbase\Service\TypoScriptService;
  * {
  *     public function register(\CuyZ\Notiz\Core\Definition\Builder\Component\DefinitionComponents $components)
  *     {
- *         if ($components->hasSource(\CuyZ\Notiz\Core\Definition\Builder\Component\Source\DefinitionSource::SOURCE_TYPOSCRIPT)) {
- *             $components->getSource(\CuyZ\Notiz\Core\Definition\Builder\Component\Source\DefinitionSource::SOURCE_TYPOSCRIPT)
- *                 ->addTypoScriptFilePath("EXT:my_extension/Definition/TypoScript/NotiZ/setup.typoscript")
+ *         if ($this->someCustomCondition()) {
+ *             $typoScriptSource = $components->getSource(\CuyZ\Notiz\Core\Definition\Builder\Component\Source\DefinitionSource::SOURCE_TYPOSCRIPT);
+ *             $typoScriptSource->addFilePath('EXT:my_extension/Definition/TypoScript/NotiZ/setup.typoscript');
  *         }
  *     }
  * }
  * ```
  */
-class TypoScriptDefinitionSource implements DefinitionSource, SingletonInterface
+class TypoScriptDefinitionSource extends FileDefinitionSource
 {
-    /**
-     * @var array
-     */
-    protected $filePaths = [];
-
     /**
      * @var ConfigurationObjectInstance
      */
@@ -72,33 +78,6 @@ class TypoScriptDefinitionSource implements DefinitionSource, SingletonInterface
     public function __construct(TypoScriptService $typoScriptService)
     {
         $this->typoScriptService = $typoScriptService;
-    }
-
-    /**
-     * Registers a TypoScript file that should contain definition for the API.
-     *
-     * See class description for more information.
-     *
-     * @param string $path
-     * @return $this
-     *
-     * @throws FileNotFoundException
-     */
-    public function addTypoScriptFilePath($path)
-    {
-        if (isset($this->filePaths[$path])) {
-            return $this;
-        }
-
-        $absolutePath = GeneralUtility::getFileAbsFileName($path);
-
-        if (false === file_exists($absolutePath)) {
-            throw FileNotFoundException::definitionSourceTypoScriptFileNotFound($path);
-        }
-
-        $this->filePaths[$path] = $absolutePath;
-
-        return $this;
     }
 
     /**

--- a/Documentation/Markdown/Developers/Definition/Add-file-definition.md
+++ b/Documentation/Markdown/Developers/Definition/Add-file-definition.md
@@ -1,0 +1,76 @@
+# Add file definition
+
+Adding a new definition file is easy, you just have to add a piece of code in 
+the `ext_localconf.php` file of your extension.
+
+Sometimes you may need more complex logic, in that case see chapter 
+“[Advanced definition handling](Advanced-definition-handling.md)”.
+
+## TypoScript definition file
+
+> *`my_extension/ext_localconf.php`*
+```php
+<?php
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['NotiZ']['Definition']['Source'][\CuyZ\Notiz\Domain\Definition\Builder\Component\Source\TypoScriptDefinitionSource::class][]
+    = 'EXT:my_extension/Configuration/TypoScript/MyCustomDefinition.typoscript';
+```
+
+> *`my_extension/Configuration/TypoScript/MyCustomDefinition.typoscript`*
+```
+notiz {
+    notifications {
+        /*
+         * Modifying the provided email notification settings…
+         */
+        entityEmail {
+            settings {
+                /*
+                 * These recipients will be available by default in every 
+                 * email notification record.
+                 */
+                globalRecipients {
+                     10 = webmaster@acme.com
+                }
+            }
+        }
+    }
+    
+    eventGroups {
+        /*
+         * We add a new event group for our custom events.
+         */
+        my_extension {
+            label = Events for My Extension
+
+            events {
+                /*
+                 * Contact form is sent
+                 * --------------------
+                 *
+                 * This event is bound to a signal sent by the contact 
+                 * controller. It contains data about the user who submitted
+                 * the form, that will be available in the notifications
+                 * markers.
+                 */
+                contactFormSent {
+                    label = Contact form sent
+
+                    className = MyVendor\MyExtension\Event\ContactFormSentEvent
+
+                    connection {
+                        type = signal
+
+                        className = MyVendor\MyContactExtension\Controller\ContactController
+                        name = contactFormSent
+                    }
+                }
+            }
+        }
+    }
+}
+```
+
+---
+
+[:books: Documentation index](../../README.md)
+

--- a/Documentation/Markdown/Developers/Definition/Advanced-definition-handling.md
+++ b/Documentation/Markdown/Developers/Definition/Advanced-definition-handling.md
@@ -1,11 +1,9 @@
-# Add TypoScript definition
+# Advanced definition handling
 
-NotiZ is based on a huge configuration object (called the “*definition*”) that 
-allows integrators to set up how events and notifications will be processed 
-during runtime.
-
-If you want to extend NotiZ or edit some existing definition value, you will 
-need to register a path to an existing TypoScript file.
+In some cases you may need to manipulate definition using PHP. To do so, you 
+will need a definition component service that will allow you adding new sources
+for the definition (for instance TypoScript files), or even modifying the 
+definition object once it has been created.
 
 ## 1. Register a definition component service
 
@@ -19,19 +17,19 @@ $dispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Ex
 $dispatcher->connect(
     \CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder::class,
     \CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder::COMPONENTS_SIGNAL,
-    \Vendor\MyExtension\Service\DefinitionComponentService::class,
+    \Vendor\MyExtension\Domain\Definition\Builder\Component\DefinitionComponentService::class,
     'registerDefinitionComponents'
 );
 ```
 
-## 2. Register TypoScript file path
+## 2. Create the definition component service
 
-Now you need to create the actual definition component service:
+Now you need to write the code of the actual definition component service:
 
-> *`my_extension/Classes/Service/DefinitionComponentService.php`*
+> *`my_extension/Classes/Domain/Definition/Builder/Component/DefinitionComponentService.php`*
 ```php
 <?php
-namespace Vendor\MyExtension\Service;
+namespace Vendor\MyExtension\Domain\Definition\Builder\Component;
 
 use CuyZ\Notiz\Core\Definition\Builder\Component\DefinitionComponents;
 use CuyZ\Notiz\Domain\Definition\Builder\Component\Source\TypoScriptDefinitionSource;
@@ -44,17 +42,17 @@ class DefinitionComponentService implements SingletonInterface
      */
     public function registerDefinitionComponents(DefinitionComponents $definitionComponents)
     {
-        /** @var TypoScriptDefinitionSource $typoScriptSource */
-        $typoScriptSource = $definitionComponents->getSource(TypoScriptDefinitionSource::class);
-
-        $typoScriptSource->addTypoScriptFilePath('EXT:my_extension/Configuration/TypoScript/MyCustomDefinition.typoscript');
+        if ($this->someCustomCondition()) {
+            /** @var TypoScriptDefinitionSource $typoScriptSource */
+            $typoScriptSource = $definitionComponents->getSource(TypoScriptDefinitionSource::class);
+    
+            $typoScriptSource->addFilePath('EXT:my_extension/Configuration/TypoScript/MyCustomDefinition.typoscript');
+        }
     }
 }
 ```
 
-## 3. Write custom definition 
-
-Finally, you can write definition in your newly registered file:
+## 3. Write definition in the file
 
 > *`my_extension/Configuration/TypoScript/MyCustomDefinition.typoscript`*
 ```
@@ -113,4 +111,4 @@ notiz {
 
 ---
 
-[:books: Documentation index](../README.md)
+[:books: Documentation index](../../README.md)

--- a/Documentation/Markdown/Developers/Definition/Advanced-definition-handling.md
+++ b/Documentation/Markdown/Developers/Definition/Advanced-definition-handling.md
@@ -1,7 +1,7 @@
 # Advanced definition handling
 
 In some cases you may need to manipulate the definition using PHP. To do so, you 
-will need a definition component service that will allow you adding new sources
+will need a definition component service that will allow you to add new sources
 for the definition (for instance TypoScript files), or even modifying the 
 definition object once it has been created.
 

--- a/Documentation/Markdown/Developers/Definition/Advanced-definition-handling.md
+++ b/Documentation/Markdown/Developers/Definition/Advanced-definition-handling.md
@@ -1,6 +1,6 @@
 # Advanced definition handling
 
-In some cases you may need to manipulate definition using PHP. To do so, you 
+In some cases you may need to manipulate the definition using PHP. To do so, you 
 will need a definition component service that will allow you adding new sources
 for the definition (for instance TypoScript files), or even modifying the 
 definition object once it has been created.

--- a/Documentation/Markdown/Developers/Definition/What-is-definition.md
+++ b/Documentation/Markdown/Developers/Definition/What-is-definition.md
@@ -1,0 +1,22 @@
+# What is the definition
+
+NotiZ is based on a configuration object, called the “*definition*”. It allows 
+administrators to manage how events and notifications will be processed during 
+runtime.
+
+If you want to register a new event or configure notifications, you will need to 
+extend the definition. Definition values can be written inside files in your own 
+extension. 
+
+The most simple way to register a definition file is to add a piece of code in
+the `ext_localconf.php` file of your extension; find more information in the 
+chapter “[Add file definition](Add-file-definition.md)”.
+
+If you need more complex logic, you can use a so-called “definition component 
+service”; see chapter 
+“[Advanced definition handling](Advanced-definition-handling.md)” for more 
+information. 
+
+---
+
+[:books: Documentation index](../../README.md)

--- a/Documentation/Markdown/Developers/Definition/What-is-definition.md
+++ b/Documentation/Markdown/Developers/Definition/What-is-definition.md
@@ -8,7 +8,7 @@ If you want to register a new event or configure notifications, you will need to
 extend the definition. Definition values can be written inside files in your own 
 extension. 
 
-The most simple way to register a definition file is to add a piece of code in
+The simplest way to register a definition file is to add a piece of code in
 the `ext_localconf.php` file of your extension; find more information in the 
 chapter “[Add file definition](Add-file-definition.md)”.
 

--- a/Documentation/Markdown/README.md
+++ b/Documentation/Markdown/README.md
@@ -33,6 +33,9 @@ You can find below documentation on how to use and extend NotiZ.
         - Extension `form`
             - [Form finisher](./Form/DispatchFormNotification.md)
 - Developers
-    - [Add TypoScript definition](Developers/Add-TypoScript-definition.md)
+    - Definition
+        - [What is the definition](Developers/Definition/What-is-definition.md)
+        - [Add file definition](Developers/Definition/Add-file-definition.md)
+        - [Advanced definition handling](Developers/Definition/Advanced-definition-handling.md)
     - [Signals provided by the extension](Developers/Signals-connection.md)
 - [Known issues](Known-issues.md)


### PR DESCRIPTION
Files containing definition values can now be added in a dramatically
more simple way: registering a definition component service is not
absolutely needed anymore.

One can just add the following piece of code to the `ext_localconf.php`
file of his/her extension:

```
$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['NotiZ']['Definition']['Source'][\CuyZ\Notiz\Domain\Definition\Builder\Component\Source\TypoScriptDefinitionSource::class][]
    = 'EXT:my_extension/Configuration/TypoScript/MyCustomDefinition.typoscript';
```

Please note that the following method has been renamed. Calls to this
method must be changed as well.

```
\CuyZ\Notiz\Domain\Definition\Builder\Component\Source\TypoScriptDefinitionSource::addTypoScriptFilePath($path)
```

now becomes:

```
\CuyZ\Notiz\Domain\Definition\Builder\Component\Source\TypoScriptDefinitionSource::addFilePath($path)
```