### PR TITLE
[BUGFIX] Allow access to array values from a scalar index

### DIFF
--- a/Classes/Core/Property/Service/MarkerParser.php
+++ b/Classes/Core/Property/Service/MarkerParser.php
@@ -87,8 +87,8 @@ class MarkerParser implements SingletonInterface
         preg_match_all(
             '/{
                 (
-                    ([a-z]+[a-z0-1-_]*)           # The root variable
-                    (?:\.[a-z]+[a-z0-1-_]*)*      # The other parts
+                    ([a-z]+[a-z0-9-_]*)           # The root variable
+                    (?:\.[a-z0-9-_]+)*            # The other parts
                 )
             }/xi',
             $string,


### PR DESCRIPTION
For an array like this:
```
$data = [
    ['foo' => 'value 0'],
    ['foo' => 'value 1'],
];
```

It is now possible to use this marker: `{data.0.foo}`

fixes #141