### PR TITLE
[BUGFIX] Prevent toolbar Ajax request to run again when it failed

### DIFF
--- a/Resources/Public/JavaScript/Toolbar.js
+++ b/Resources/Public/JavaScript/Toolbar.js
@@ -65,11 +65,11 @@ define([
                         } else {
                             timer.defaultTick();
                         }
+
+                        timer.launch();
                     })
                     .fail(menu.error)
                     .always(function () {
-                        timer.launch();
-
                         if (typeof callback !== 'undefined') {
                             callback();
                         }
@@ -99,8 +99,6 @@ define([
              * message is displayed.
              */
             error: function () {
-                timer.fastTick();
-
                 // Reset the icon with its initial value.
                 icon.update();
 


### PR DESCRIPTION
In order to prevent potential error log spamming, when the toolbar Ajax
request fails, it won't automatically run again.