### PR TITLE
[FEATURE] Handle priority for file definition sources

### DIFF
--- a/Classes/Core/Exception/FileNotFoundException.php
+++ b/Classes/Core/Exception/FileNotFoundException.php
@@ -18,16 +18,16 @@ namespace CuyZ\Notiz\Core\Exception;
 
 class FileNotFoundException extends NotizException
 {
-    const DEFINITION_SOURCE_TYPOSCRIPT_FILE_NOT_FOUND = 'The TypoScript definition file at path `%s` was not found.';
+    const DEFINITION_SOURCE_FILE_NOT_FOUND = 'The definition file at path `%s` was not found.';
 
     /**
      * @param string $filePath
      * @return self
      */
-    public static function definitionSourceTypoScriptFileNotFound($filePath)
+    public static function definitionSourceFileNotFound($filePath)
     {
         return self::makeNewInstance(
-            self::DEFINITION_SOURCE_TYPOSCRIPT_FILE_NOT_FOUND,
+            self::DEFINITION_SOURCE_FILE_NOT_FOUND,
             1503853091,
             [$filePath]
         );

--- a/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
+++ b/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
@@ -31,6 +31,8 @@ use TYPO3\CMS\Core\Utility\VersionNumberUtility;
  */
 class DefaultDefinitionComponents implements SingletonInterface
 {
+    const DEFAULT_DEFINITION_FILE_PRIORITY = 1337;
+
     /**
      * @var bool
      */
@@ -66,18 +68,27 @@ class DefaultDefinitionComponents implements SingletonInterface
         /** @var TypoScriptDefinitionSource $typoScriptDefinitionSource */
         $typoScriptDefinitionSource = $components->addSource(DefinitionSource::SOURCE_TYPOSCRIPT);
 
-        // Default channels.
-        $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Channel/Channels.Default.typoscript');
+        foreach ($this->getDefaultFiles() as $file) {
+            $typoScriptDefinitionSource->addFilePath($file, self::DEFAULT_DEFINITION_FILE_PRIORITY);
+        }
+    }
 
-        // Default notifications.
-        $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Notification/Notifications.typoscript');
+    /**
+     * @return array
+     */
+    private function getDefaultFiles()
+    {
+        $defaultFiles = [
+            NotizConstants::TYPOSCRIPT_PATH . 'Channel/Channels.Default.typoscript',
+            NotizConstants::TYPOSCRIPT_PATH . 'Notification/Notifications.typoscript',
+        ];
 
         // TYPO3 events can be enabled/disabled in the extension configuration.
         if ($this->extensionConfigurationService->getConfigurationValue('events.typo3')) {
-            $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.TYPO3.typoscript');
+            $defaultFiles[] = NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.TYPO3.typoscript';
 
             if (ExtensionManagementUtility::isLoaded('scheduler')) {
-                $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Scheduler.typoscript');
+                $defaultFiles[] = NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Scheduler.typoscript';
             }
         }
 
@@ -85,7 +96,9 @@ class DefaultDefinitionComponents implements SingletonInterface
         if (ExtensionManagementUtility::isLoaded('form')
             && version_compare(VersionNumberUtility::getCurrentTypo3Version(), '8.0.0', '>=')
         ) {
-            $typoScriptDefinitionSource->addFilePath(NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Form.typoscript');
+            $defaultFiles[] = NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Form.typoscript';
         }
+
+        return $defaultFiles;
     }
 }

--- a/Classes/Domain/Definition/Builder/Component/Source/TypoScriptDefinitionSource.php
+++ b/Classes/Domain/Definition/Builder/Component/Source/TypoScriptDefinitionSource.php
@@ -92,7 +92,7 @@ class TypoScriptDefinitionSource extends FileDefinitionSource
     {
         $content = '';
 
-        foreach ($this->filePaths as $path) {
+        foreach ($this->filePaths() as $path) {
             $content .= GeneralUtility::getUrl($path) . LF;
         }
 

--- a/Documentation/06-Administrator/01-Definition/03-AdvancedDefinitionHandling.rst
+++ b/Documentation/06-Administrator/01-Definition/03-AdvancedDefinitionHandling.rst
@@ -57,6 +57,20 @@ Now the actual definition component service can be written:
         }
     }
 
+.. hint::
+
+    A priority can be given to the file for sorting purposes. The files with the
+    highest priority will be handled first; this means that the files with the
+    lowest priority have more chance to override definition values.
+
+    By default, a file has a priority of ``0``.
+
+    .. code-block:: php
+
+        // The definition values from `$file2` will override the ones from `$file1`.
+        $typoScriptSource->addFilePath($file1, 50);
+        $typoScriptSource->addFilePath($file2, 10);
+
 3. Write definition in the file
 -------------------------------
 


### PR DESCRIPTION
The file definition sources are now sorted by the priority they are
given.

Default definition files have a high priority, to easily allow other
files to override definition values.