### PR TITLE
[BUGFIX] Distinct TCA processors and data providers

### DIFF
--- a/Classes/Backend/FormEngine/DataProvider/DefaultEventFromGet.php
+++ b/Classes/Backend/FormEngine/DataProvider/DefaultEventFromGet.php
@@ -18,6 +18,7 @@ namespace CuyZ\Notiz\Backend\FormEngine\DataProvider;
 
 use CuyZ\Notiz\Core\Definition\DefinitionService;
 use CuyZ\Notiz\Core\Definition\Tree\Definition;
+use CuyZ\Notiz\Core\Notification\TCA\EntityTcaWriter;
 use CuyZ\Notiz\Service\Container;
 use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -46,7 +47,7 @@ class DefaultEventFromGet implements FormDataProviderInterface
         }
 
         // The feature needs to be enabled in the `ctrl` section of the TCA.
-        if (!isset($result['processedTca']['ctrl'][self::ENABLE_DEFAULT_VALUE])) {
+        if (!isset($result['processedTca']['ctrl'][EntityTcaWriter::NOTIFICATION_ENTITY]['dataProvider'][self::ENABLE_DEFAULT_VALUE])) {
             return $result;
         }
 

--- a/Classes/Backend/FormEngine/DataProvider/DefinitionError.php
+++ b/Classes/Backend/FormEngine/DataProvider/DefinitionError.php
@@ -56,7 +56,7 @@ class DefinitionError implements FormDataProviderInterface
     {
         $tableName = $result['tableName'];
 
-        if (!isset($GLOBALS['TCA'][$tableName]['ctrl'][EntityTcaWriter::ENTITY_NOTIFICATION])) {
+        if (!isset($GLOBALS['TCA'][$tableName]['ctrl'][EntityTcaWriter::NOTIFICATION_ENTITY])) {
             return $result;
         }
 

--- a/Classes/Core/Notification/TCA/EntityTcaWriter.php
+++ b/Classes/Core/Notification/TCA/EntityTcaWriter.php
@@ -17,8 +17,8 @@
 namespace CuyZ\Notiz\Core\Notification\TCA;
 
 use CuyZ\Notiz\Backend\FormEngine\DataProvider\DefaultEventFromGet;
-use CuyZ\Notiz\Backend\FormEngine\DataProvider\EventConfigurationProvider;
 use CuyZ\Notiz\Core\Notification\Service\NotificationTcaService;
+use CuyZ\Notiz\Core\Notification\TCA\Processor\EventConfigurationProcessor;
 use CuyZ\Notiz\Service\Traits\SelfInstantiateTrait;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
@@ -28,7 +28,7 @@ abstract class EntityTcaWriter implements SingletonInterface
 {
     use SelfInstantiateTrait;
 
-    const ENTITY_NOTIFICATION = '__entityNotification';
+    const NOTIFICATION_ENTITY = 'notificationEntity';
 
     const LLL = 'LLL:EXT:notiz/Resources/Private/Language/Notification/Entity/Entity.xlf';
 
@@ -151,10 +151,14 @@ abstract class EntityTcaWriter implements SingletonInterface
             'searchFields' => 'title,event',
             'iconfile' => $this->service->getNotificationIconPath(),
 
-            self::ENTITY_NOTIFICATION => true,
-
-            DefaultEventFromGet::ENABLE_DEFAULT_VALUE => true,
-            EventConfigurationProvider::COLUMN => 'event_configuration_flex',
+            self::NOTIFICATION_ENTITY => [
+                'processor' => [
+                    EventConfigurationProcessor::class,
+                ],
+                'dataProvider' => [
+                    DefaultEventFromGet::ENABLE_DEFAULT_VALUE => true,
+                ]
+            ],
         ];
     }
 
@@ -294,7 +298,7 @@ abstract class EntityTcaWriter implements SingletonInterface
 
             /**
              * This FlexForm field is fully configured in:
-             * @see \CuyZ\Notiz\Backend\FormEngine\DataProvider\EventConfigurationProvider
+             * @see \CuyZ\Notiz\Core\Notification\TCA\Processor\EventConfigurationProcessor
              */
             'event_configuration_flex' => [
                 'label' => self::LLL . ':field.event_configuration',

--- a/Classes/Core/Notification/TCA/Processor/BodySlotsProcessor.php
+++ b/Classes/Core/Notification/TCA/Processor/BodySlotsProcessor.php
@@ -14,7 +14,7 @@
  * http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace CuyZ\Notiz\Backend\FormEngine\DataProvider;
+namespace CuyZ\Notiz\Core\Notification\TCA\Processor;
 
 use CuyZ\Notiz\Core\Definition\Tree\EventGroup\Event\EventDefinition;
 use CuyZ\Notiz\Core\Notification\Settings\NotificationSettings;
@@ -30,9 +30,9 @@ use CuyZ\Notiz\View\Slot\Service\SlotViewService;
  * The body is a FlexForm field, where definition sheets are handled with
  * so-called "slot" that can be registered within the template of the mail.
  */
-class BodySlotsProvider extends GracefulProvider
+class BodySlotsProcessor extends GracefulProcessor
 {
-    const COLUMN = '__mailBody';
+    const COLUMN = 'body';
 
     /**
      * @var SlotViewService
@@ -56,27 +56,12 @@ class BodySlotsProvider extends GracefulProvider
     }
 
     /**
-     * @param array $result
-     * @return array
+     * @param string $tableName
      */
-    public function process(array $result)
+    public function doProcess($tableName)
     {
-        $tableName = $result['tableName'];
-
-        if (!isset($GLOBALS['TCA'][$tableName]['ctrl'][self::COLUMN])) {
-            return $result;
-        }
-
-        $columnName = $GLOBALS['TCA'][$tableName]['ctrl'][self::COLUMN];
-
-        if (!isset($GLOBALS['TCA'][$tableName]['columns'][$columnName])) {
-            return $result;
-        }
-
-        $GLOBALS['TCA'][$tableName]['columns'][$columnName]['displayCond'] = $this->getMailBodyDisplayCond();
-        $GLOBALS['TCA'][$tableName]['columns'][$columnName]['config']['ds'] = $this->getMailBodyFlexFormList();
-
-        return $result;
+        $GLOBALS['TCA'][$tableName]['columns'][self::COLUMN]['displayCond'] = $this->getMailBodyDisplayCond();
+        $GLOBALS['TCA'][$tableName]['columns'][self::COLUMN]['config']['ds'] = $this->getMailBodyFlexFormList();
     }
 
     /**

--- a/Classes/Core/Notification/TCA/Processor/BodySlotsProcessor.php
+++ b/Classes/Core/Notification/TCA/Processor/BodySlotsProcessor.php
@@ -16,7 +16,6 @@
 
 namespace CuyZ\Notiz\Core\Notification\TCA\Processor;
 
-use CuyZ\Notiz\Core\Definition\Tree\EventGroup\Event\EventDefinition;
 use CuyZ\Notiz\Core\Notification\Settings\NotificationSettings;
 use CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\EntityEmailNotification;
 use CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\Settings\EntityEmailSettings;
@@ -78,9 +77,8 @@ class BodySlotsProcessor extends GracefulProcessor
         $eventsWithoutSlots = [];
         $events = $this->slotViewService->getEventsWithoutSlots($this->getNotificationSettings()->getView());
 
-        foreach ($events as $event => $view) {
-            /** @var EventDefinition $event */
-            $eventsWithoutSlots[] = $event->getFullIdentifier();
+        foreach ($events as $view) {
+            $eventsWithoutSlots[] = $view->getEventDefinition()->getFullIdentifier();
         }
 
         return [

--- a/Classes/Core/Notification/TCA/Processor/EventConfigurationProcessor.php
+++ b/Classes/Core/Notification/TCA/Processor/EventConfigurationProcessor.php
@@ -14,7 +14,7 @@
  * http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace CuyZ\Notiz\Backend\FormEngine\DataProvider;
+namespace CuyZ\Notiz\Core\Notification\TCA\Processor;
 
 use CuyZ\Notiz\Core\Notification\Service\LegacyNotificationTcaService;
 use TYPO3\CMS\Core\Utility\VersionNumberUtility;
@@ -26,38 +26,14 @@ use TYPO3\CMS\Core\Utility\VersionNumberUtility;
  * using FlexForm. Display conditions are dynamically assigned to show the
  * correct definition depending on the selected event.
  */
-class EventConfigurationProvider extends GracefulProvider
+class EventConfigurationProcessor extends GracefulProcessor
 {
-    const COLUMN = '__eventConfiguration';
-
-    /**
-     * @param array $result
-     * @return array
-     */
-    public function process(array $result)
-    {
-        $tableName = $result['tableName'];
-
-        if (!isset($GLOBALS['TCA'][$tableName]['ctrl'][self::COLUMN])) {
-            return $result;
-        }
-
-        $columnName = $GLOBALS['TCA'][$tableName]['ctrl'][self::COLUMN];
-
-        if (!isset($GLOBALS['TCA'][$tableName]['columns'][$columnName])) {
-            return $result;
-        }
-
-        $this->fillEventConfigurationTca($tableName, $columnName);
-
-        return $result;
-    }
+    const COLUMN = 'event_configuration_flex';
 
     /**
      * @param string $tableName
-     * @param string $columnName
      */
-    private function fillEventConfigurationTca($tableName, $columnName)
+    protected function doProcess($tableName)
     {
         $flexFormDs = [];
         $displayConditions = [];
@@ -75,7 +51,7 @@ class EventConfigurationProvider extends GracefulProvider
 
         // If no definition is found, the field is not shown at all.
         if (empty($flexFormDs)) {
-            $GLOBALS['TCA'][$tableName]['columns'][$columnName]['config'] = ['type' => 'passthrough'];
+            $GLOBALS['TCA'][$tableName]['columns'][self::COLUMN]['config'] = ['type' => 'passthrough'];
         }
 
         /**
@@ -83,9 +59,9 @@ class EventConfigurationProvider extends GracefulProvider
          */
         $flexFormDs['default'] = 'FILE:EXT:notiz/Configuration/FlexForm/Event/DefaultEventFlexForm.xml';
 
-        $GLOBALS['TCA'][$tableName]['columns'][$columnName]['config']['ds'] = $flexFormDs;
+        $GLOBALS['TCA'][$tableName]['columns'][self::COLUMN]['config']['ds'] = $flexFormDs;
 
-        $GLOBALS['TCA'][$tableName]['columns'][$columnName]['displayCond'] = version_compare(VersionNumberUtility::getCurrentTypo3Version(), '8.0.0', '<')
+        $GLOBALS['TCA'][$tableName]['columns'][self::COLUMN]['displayCond'] = version_compare(VersionNumberUtility::getCurrentTypo3Version(), '8.0.0', '<')
             ? 'USER:' . LegacyNotificationTcaService::class . '->displayEventFlexForm:' . $tableName . ':' . implode(',', $displayConditions)
             : 'FIELD:event:IN:' . implode(',', $displayConditions);
     }

--- a/Classes/Core/Notification/TCA/Processor/GracefulProcessor.php
+++ b/Classes/Core/Notification/TCA/Processor/GracefulProcessor.php
@@ -14,19 +14,19 @@
  * http://www.gnu.org/licenses/gpl-3.0.html
  */
 
-namespace CuyZ\Notiz\Backend\FormEngine\DataProvider;
+namespace CuyZ\Notiz\Core\Notification\TCA\Processor;
 
 use CuyZ\Notiz\Core\Definition\DefinitionService;
 use CuyZ\Notiz\Service\Container;
 use CuyZ\Notiz\Service\ViewService;
 use Exception;
 use Throwable;
-use TYPO3\CMS\Backend\Form\FormDataProviderInterface;
+use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * This provider must be used to complete the TCA of entity notifications, for
+ * This processor must be used to complete the TCA of entity notifications, for
  * parts that require complex logic that may be failing under certain
  * circumstances (meaning an exception can be thrown for any reason).
  *
@@ -34,12 +34,12 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * and put in cache, because if something fails it would crash for the whole
  * backend.
  *
- * Using this graceful provider, if something breaks during the execution of the
- * child provider, the error is caught in order to prevent showing the fatal
- * error to the user; instead, a message is displayed with some information about
- * the exception.
+ * Using this graceful processor, if something breaks during the execution of
+ * the child processor, the error is caught in order to prevent showing the
+ * fatal error to the user; instead, a message is displayed with some
+ * information about the exception.
  */
-abstract class GracefulProvider implements FormDataProviderInterface
+abstract class GracefulProcessor implements SingletonInterface
 {
     /**
      * @var DefinitionService
@@ -61,18 +61,19 @@ abstract class GracefulProvider implements FormDataProviderInterface
     }
 
     /**
-     * @param array $result
-     * @return array
+     * @param string $tableName
      * @throws Throwable
      */
-    final public function addData(array $result)
+    final public function process($tableName)
     {
         if ($this->definitionService->getValidationResult()->hasErrors()) {
-            return $result;
+            return;
         }
 
+        $exception = null;
+
         try {
-            return $this->process($result);
+            $this->doProcess($tableName);
         } catch (Throwable $exception) {
         } catch (Exception $exception) {
             // @PHP7
@@ -84,19 +85,16 @@ abstract class GracefulProvider implements FormDataProviderInterface
             }
 
             ArrayUtility::mergeRecursiveWithOverrule(
-                $GLOBALS['TCA'][$result['tableName']],
+                $GLOBALS['TCA'][$tableName],
                 $this->getDefinitionErrorTca($exception)
             );
         }
-
-        return $result;
     }
 
     /**
-     * @param array $result
-     * @return array
+     * @param string $tableName
      */
-    abstract protected function process(array $result);
+    abstract protected function doProcess($tableName);
 
     /**
      * @param Throwable $exception

--- a/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
+++ b/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright (C) 2018
+ *
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ *
+ * This file is part of the NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Core\Notification\TCA\Processor;
+
+use CuyZ\Notiz\Core\Notification\TCA\EntityTcaWriter;
+use TYPO3\CMS\Core\Database\TableConfigurationPostProcessingHookInterface;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class GracefulProcessorRunner implements SingletonInterface, TableConfigurationPostProcessingHookInterface
+{
+    /**
+     * This method runs just after the TCA was registered.
+     *
+     * It instantiates and runs a list of "graceful processors" that modify some
+     * TCA that requires more complex logic (which can fail for any reason).
+     */
+    public function processData()
+    {
+        foreach ($GLOBALS['TCA'] as $tableName => $configuration) {
+            if (!isset($configuration['ctrl'][EntityTcaWriter::NOTIFICATION_ENTITY]['processor'])) {
+                continue;
+            }
+
+            foreach ($configuration['ctrl'][EntityTcaWriter::NOTIFICATION_ENTITY]['processor'] as $processorClassName) {
+                /** @var GracefulProcessor $processor */
+                $processor = GeneralUtility::makeInstance($processorClassName);
+
+                $processor->process($tableName);
+            }
+        }
+    }
+}

--- a/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
+++ b/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
@@ -2,11 +2,10 @@
 
 /*
  * Copyright (C) 2018
- *
- * Romain Canon <romain.hydrocanon@gmail.com>
  * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
  *
- * This file is part of the NotiZ project.
+ * This file is part of the TYPO3 NotiZ project.
  * It is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License, either
  * version 3 of the License, or any later version.

--- a/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
+++ b/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
@@ -32,6 +32,7 @@ class GracefulProcessorRunner implements SingletonInterface, TableConfigurationP
     public function processData()
     {
         foreach ($GLOBALS['TCA'] as $tableName => $configuration) {
+            // @PHP7
             if (!isset($configuration['ctrl'][EntityTcaWriter::NOTIFICATION_ENTITY]['processor'])) {
                 continue;
             }

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaWriter.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaWriter.php
@@ -16,8 +16,8 @@
 
 namespace CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\TCA;
 
-use CuyZ\Notiz\Backend\FormEngine\DataProvider\BodySlotsProvider;
 use CuyZ\Notiz\Core\Notification\TCA\EntityTcaWriter;
+use CuyZ\Notiz\Core\Notification\TCA\Processor\BodySlotsProcessor;
 
 class EntityEmailTcaWriter extends EntityTcaWriter
 {
@@ -125,7 +125,7 @@ class EntityEmailTcaWriter extends EntityTcaWriter
 
                 /**
                  * This FlexForm field is fully configured in:
-                 * @see \CuyZ\Notiz\Backend\FormEngine\DataProvider\BodySlotsProvider
+                 * @see \CuyZ\Notiz\Core\Notification\TCA\Processor\BodySlotsProcessor
                  */
                 'body' => [
                     'exclude' => 1,
@@ -262,7 +262,8 @@ class EntityEmailTcaWriter extends EntityTcaWriter
 
         $ctrl['requestUpdate'] .= ',sender_custom';
         $ctrl['searchFields'] .= ',sender,sender_custom,send_to,send_to_provided,send_cc,send_cc_provided,send_bcc,send_bcc_provided,subject,body';
-        $ctrl[BodySlotsProvider::COLUMN] = 'body';
+
+        $ctrl[self::NOTIFICATION_ENTITY]['processor'][] = BodySlotsProcessor::class;
 
         return $ctrl;
     }

--- a/Classes/Service/Extension/LocalConfigurationService.php
+++ b/Classes/Service/Extension/LocalConfigurationService.php
@@ -18,10 +18,9 @@ namespace CuyZ\Notiz\Service\Extension;
 
 use CuyZ\Notiz\Backend\FormEngine\DataProvider\DefaultEventFromGet;
 use CuyZ\Notiz\Backend\FormEngine\DataProvider\DefinitionError;
-use CuyZ\Notiz\Backend\FormEngine\DataProvider\EventConfigurationProvider;
-use CuyZ\Notiz\Backend\FormEngine\DataProvider\BodySlotsProvider;
 use CuyZ\Notiz\Backend\ToolBarItems\NotificationsToolbarItem;
 use CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder;
+use CuyZ\Notiz\Core\Notification\TCA\Processor\GracefulProcessorRunner;
 use CuyZ\Notiz\Core\Support\NotizConstants;
 use CuyZ\Notiz\Domain\Definition\Builder\Component\DefaultDefinitionComponents;
 use CuyZ\Notiz\Service\Container;
@@ -90,6 +89,7 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
         $this->registerNotificationFlexFormProcessorHook();
         $this->registerInternalCache();
         $this->registerIcons();
+        $this->registerNotificationProcessorRunner();
         $this->registerFormEngineComponents();
         $this->resetTypeConvertersArray();
         $this->overrideScheduler();
@@ -240,6 +240,16 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
     }
 
     /**
+     * Registers the notification processor runner.
+     *
+     * @see \CuyZ\Notiz\Core\Notification\TCA\Processor\GracefulProcessorRunner
+     */
+    protected function registerNotificationProcessorRunner()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['extTablesInclusion-PostProcessing'][] = GracefulProcessorRunner::class;
+    }
+
+    /**
      * Registers components for TYPO3 form engine.
      */
     protected function registerFormEngineComponents()
@@ -263,19 +273,5 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
          */
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][DefinitionError::class] = [];
         $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][InitializeProcessedTca::class]['depends'][] = DefinitionError::class;
-
-        /*
-         * A data provider is used to dynamically configure the event
-         * configuration fields, that depends on the definition.
-         */
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][EventConfigurationProvider::class] = [];
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][InitializeProcessedTca::class]['depends'][] = EventConfigurationProvider::class;
-
-        /*
-         * A data provider is used to dynamically configure the body of the mail
-         * notification, which depends on the slots used in its template.
-         */
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][BodySlotsProvider::class] = [];
-        $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['formDataGroup']['tcaDatabaseRecord'][InitializeProcessedTca::class]['depends'][] = BodySlotsProvider::class;
     }
 }

--- a/Classes/View/Slot/Service/SlotViewService.php
+++ b/Classes/View/Slot/Service/SlotViewService.php
@@ -116,7 +116,7 @@ class SlotViewService implements SingletonInterface
 
     /**
      * @param ViewPathsAware $viewPaths
-     * @return Generator
+     * @return Generator|SlotView[]
      */
     public function getEventsWithoutSlots(ViewPathsAware $viewPaths)
     {


### PR DESCRIPTION
Some data providers were actually not acting on an actual notification
record, but modifying global TCA configuration instead.

Because of this, TYPO3 core would misunderstand things, like FlexForm
configuration done dynamically. This would result in strange behaviour
like empty paragraph added on text columns with RTE inside FlexForm
fields.

This commit separates these processors in a distinct namespace, with a
brand new role and interface.

Fixes #181