### PR TITLE
[!!!][TASK] Use strict types for PHP classes 

### DIFF
--- a/Classes/Backend/FormEngine/ButtonBar/ShowNotificationDetailsButton.php
+++ b/Classes/Backend/FormEngine/ButtonBar/ShowNotificationDetailsButton.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -81,7 +82,7 @@ class ShowNotificationDetailsButton implements SingletonInterface
     /**
      * @param NotificationDefinition $notificationDefinition
      * @param EditDocumentController $controller
-     * @return Viewable
+     * @return Viewable|null [PHP 7.1]
      */
     protected function getNotification(NotificationDefinition $notificationDefinition, EditDocumentController $controller)
     {
@@ -108,7 +109,7 @@ class ShowNotificationDetailsButton implements SingletonInterface
         }
 
         /** @var Viewable $notification */
-        $notification = $notificationDefinition->getProcessor()->getNotificationFromIdentifier($uid);
+        $notification = $notificationDefinition->getProcessor()->getNotificationFromIdentifier((string)$uid);
 
         return $notification;
     }
@@ -142,7 +143,7 @@ class ShowNotificationDetailsButton implements SingletonInterface
      * @param EditDocumentController $controller
      * @return ModuleTemplate
      */
-    protected function getModuleTemplate(EditDocumentController $controller)
+    protected function getModuleTemplate(EditDocumentController $controller): ModuleTemplate
     {
         $reflection = new ReflectionClass($controller);
         $property = $reflection->getProperty('moduleTemplate');

--- a/Classes/Backend/FormEngine/DataProvider/DefaultEventFromGet.php
+++ b/Classes/Backend/FormEngine/DataProvider/DefaultEventFromGet.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -39,7 +40,7 @@ class DefaultEventFromGet implements FormDataProviderInterface
      * @param array $result
      * @return array
      */
-    public function addData(array $result)
+    public function addData(array $result): array
     {
         // This feature is available for new records only.
         if ($result['command'] !== 'new') {
@@ -73,7 +74,7 @@ class DefaultEventFromGet implements FormDataProviderInterface
     /**
      * @return Definition
      */
-    protected function getDefinition()
+    protected function getDefinition(): Definition
     {
         /** @var DefinitionService $definitionService */
         $definitionService = Container::get(DefinitionService::class);

--- a/Classes/Backend/FormEngine/DataProvider/DefinitionError.php
+++ b/Classes/Backend/FormEngine/DataProvider/DefinitionError.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -52,7 +53,7 @@ class DefinitionError implements FormDataProviderInterface
      * @param array $result
      * @return array
      */
-    public function addData(array $result)
+    public function addData(array $result): array
     {
         $tableName = $result['tableName'];
 
@@ -70,7 +71,7 @@ class DefinitionError implements FormDataProviderInterface
     /**
      * @return array
      */
-    private function getDefinitionErrorTca()
+    private function getDefinitionErrorTca(): array
     {
         return [
             'types' => [
@@ -92,7 +93,7 @@ class DefinitionError implements FormDataProviderInterface
     /**
      * @return string
      */
-    public function getDefinitionErrorMessage()
+    public function getDefinitionErrorMessage(): string
     {
         $view = $this->viewService->getStandaloneView('Backend/TCA/DefinitionErrorMessage');
 

--- a/Classes/Backend/FormEngine/DataProvider/HideColumns.php
+++ b/Classes/Backend/FormEngine/DataProvider/HideColumns.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -32,7 +33,7 @@ class HideColumns implements FormDataProviderInterface
      * @param array $result
      * @return array
      */
-    public function addData(array $result)
+    public function addData(array $result): array
     {
         $tableName = $result['tableName'];
 

--- a/Classes/Backend/Module/AdministrationModuleHandler.php
+++ b/Classes/Backend/Module/AdministrationModuleHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -21,7 +22,7 @@ class AdministrationModuleHandler extends ModuleHandler
     /**
      * @return string
      */
-    public function getDefaultControllerName()
+    public function getDefaultControllerName(): string
     {
         return 'Backend\\Administration\\Index';
     }
@@ -29,7 +30,7 @@ class AdministrationModuleHandler extends ModuleHandler
     /**
      * @return string
      */
-    public function getModuleName()
+    public function getModuleName(): string
     {
         return 'NotizNotiz_NotizNotizAdministration';
     }

--- a/Classes/Backend/Module/ManagerModuleHandler.php
+++ b/Classes/Backend/Module/ManagerModuleHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -25,7 +26,7 @@ class ManagerModuleHandler extends ModuleHandler
     /**
      * @return string
      */
-    public function getDefaultControllerName()
+    public function getDefaultControllerName(): string
     {
         return 'Backend\\Manager\\ListNotificationTypes';
     }
@@ -33,7 +34,7 @@ class ManagerModuleHandler extends ModuleHandler
     /**
      * @return string
      */
-    public function getModuleName()
+    public function getModuleName(): string
     {
         return 'NotizNotiz_NotizNotizManager';
     }

--- a/Classes/Backend/Module/ModuleHandler.php
+++ b/Classes/Backend/Module/ModuleHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -48,7 +49,7 @@ abstract class ModuleHandler implements SingletonInterface
      * @param string $module
      * @return ModuleHandler
      */
-    public static function for($module)
+    public static function for(string $module): ModuleHandler
     {
         /** @var ModuleHandler $moduleHandler */
         $moduleHandler = Container::get(__NAMESPACE__ . '\\' . $module . 'ModuleHandler');
@@ -59,7 +60,7 @@ abstract class ModuleHandler implements SingletonInterface
     /**
      * @return UriBuilder
      */
-    public function getUriBuilder()
+    public function getUriBuilder(): UriBuilder
     {
         return $this->uriBuilder;
     }
@@ -67,7 +68,7 @@ abstract class ModuleHandler implements SingletonInterface
     /**
      * @return bool
      */
-    public function canBeAccessed()
+    public function canBeAccessed(): bool
     {
         return Container::getBackendUser()->modAccess($GLOBALS['TBE_MODULES']['_configuration'][$this->getModuleName()], false);
     }
@@ -75,10 +76,10 @@ abstract class ModuleHandler implements SingletonInterface
     /**
      * @return string
      */
-    abstract public function getDefaultControllerName();
+    abstract public function getDefaultControllerName(): string;
 
     /**
      * @return string
      */
-    abstract public function getModuleName();
+    abstract public function getModuleName(): string;
 }

--- a/Classes/Backend/Module/ModuleHandler.php
+++ b/Classes/Backend/Module/ModuleHandler.php
@@ -45,12 +45,10 @@ abstract class ModuleHandler implements SingletonInterface
     /**
      * Returns the manager instance for the given module.
      *
-     * @PHP7 rename method to `for`
-     *
      * @param string $module
      * @return ModuleHandler
      */
-    public static function forModule($module)
+    public static function for($module)
     {
         /** @var ModuleHandler $moduleHandler */
         $moduleHandler = Container::get(__NAMESPACE__ . '\\' . $module . 'ModuleHandler');

--- a/Classes/Backend/Module/Uri/UriBuilder.php
+++ b/Classes/Backend/Module/Uri/UriBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -93,7 +94,7 @@ class UriBuilder
     /**
      * @return UriInterface
      */
-    public function build()
+    public function build(): UriInterface
     {
         $module = $this->moduleHandler->getModuleName();
         $controller = $this->controller ?: $this->moduleHandler->getDefaultControllerName();

--- a/Classes/Backend/Report/NotificationStatus.php
+++ b/Classes/Backend/Report/NotificationStatus.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -55,7 +56,7 @@ class NotificationStatus implements StatusProviderInterface, SingletonInterface
     /**
      * @return array
      */
-    public function getStatus()
+    public function getStatus(): array
     {
         $result = $this->definitionService->getValidationResult();
 

--- a/Classes/Backend/ToolBarItems/NotificationsToolbarItem.php
+++ b/Classes/Backend/ToolBarItems/NotificationsToolbarItem.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -97,7 +98,7 @@ class NotificationsToolbarItem implements ToolbarItemInterface
     /**
      * @return bool
      */
-    public function checkAccess()
+    public function checkAccess(): bool
     {
         return $this->managerModuleHandler->canBeAccessed();
     }
@@ -105,7 +106,7 @@ class NotificationsToolbarItem implements ToolbarItemInterface
     /**
      * @return string
      */
-    public function getItem()
+    public function getItem(): string
     {
         return $this->getFluidTemplateObject('Backend/ToolBar/NotificationToolBarItem')->render();
     }
@@ -113,7 +114,7 @@ class NotificationsToolbarItem implements ToolbarItemInterface
     /**
      * @return bool
      */
-    public function hasDropDown()
+    public function hasDropDown(): bool
     {
         return true;
     }
@@ -121,7 +122,7 @@ class NotificationsToolbarItem implements ToolbarItemInterface
     /**
      * @return string
      */
-    public function getDropDown()
+    public function getDropDown(): string
     {
         try {
             return $this->getDropDownFromDefinition();
@@ -137,7 +138,7 @@ class NotificationsToolbarItem implements ToolbarItemInterface
      * @param ResponseInterface $response
      * @return ResponseInterface
      */
-    public function renderMenuAction(ServerRequestInterface $request, ResponseInterface $response)
+    public function renderMenuAction(ServerRequestInterface $request, ResponseInterface $response): ResponseInterface
     {
         $this->fullMenu = true;
 
@@ -149,7 +150,7 @@ class NotificationsToolbarItem implements ToolbarItemInterface
     /**
      * @return string
      */
-    protected function getDropDownFromDefinition()
+    protected function getDropDownFromDefinition(): string
     {
         $view = $this->getFluidTemplateObject('Backend/ToolBar/NotificationToolBarDropDown');
 
@@ -184,7 +185,7 @@ class NotificationsToolbarItem implements ToolbarItemInterface
      * @param Throwable $exception
      * @return string
      */
-    protected function getErrorDropDown($exception)
+    protected function getErrorDropDown(Throwable $exception): string
     {
         $view = $this->getFluidTemplateObject('Backend/ToolBar/NotificationToolBarDropDownError');
         $view->assign('exception', $exception);
@@ -196,7 +197,7 @@ class NotificationsToolbarItem implements ToolbarItemInterface
     /**
      * @return array
      */
-    public function getAdditionalAttributes()
+    public function getAdditionalAttributes(): array
     {
         return [];
     }
@@ -204,11 +205,11 @@ class NotificationsToolbarItem implements ToolbarItemInterface
     /**
      * @return int
      */
-    public function getIndex()
+    public function getIndex(): int
     {
         $index = $this->extensionConfigurationService->getConfigurationValue('toolbar.index');
 
-        return max(min($index, 100), 0);
+        return (int)max(min($index, 100), 0);
     }
 
     /**
@@ -230,7 +231,7 @@ class NotificationsToolbarItem implements ToolbarItemInterface
      * @param string $templateName
      * @return StandaloneView
      */
-    protected function getFluidTemplateObject($templateName)
+    protected function getFluidTemplateObject(string $templateName): StandaloneView
     {
         $view = $this->viewService->getStandaloneView($templateName);
 
@@ -240,10 +241,11 @@ class NotificationsToolbarItem implements ToolbarItemInterface
     }
 
     /**
-     * @return PageRenderer|object
+     * @return PageRenderer
      */
-    protected function getPageRenderer()
+    protected function getPageRenderer(): PageRenderer
     {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return GeneralUtility::makeInstance(PageRenderer::class);
     }
 }

--- a/Classes/Backend/ToolBarItems/NotificationsToolbarItem.php
+++ b/Classes/Backend/ToolBarItems/NotificationsToolbarItem.php
@@ -22,7 +22,6 @@ use CuyZ\Notiz\Service\Container;
 use CuyZ\Notiz\Service\ExtensionConfigurationService;
 use CuyZ\Notiz\Service\LocalizationService;
 use CuyZ\Notiz\Service\ViewService;
-use Exception;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
@@ -127,11 +126,8 @@ class NotificationsToolbarItem implements ToolbarItemInterface
         try {
             return $this->getDropDownFromDefinition();
         } catch (Throwable $exception) {
-        } catch (Exception $exception) {
-            // @PHP7
+            return $this->getErrorDropDown($exception);
         }
-
-        return $this->getErrorDropDown($exception);
     }
 
     /**

--- a/Classes/Controller/Backend/Administration/IndexController.php
+++ b/Classes/Controller/Backend/Administration/IndexController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -39,7 +40,7 @@ class IndexController extends BackendController
     /**
      * @inheritdoc
      */
-    protected function getMenu()
+    protected function getMenu(): string
     {
         return Menu::ADMINISTRATION_INDEX;
     }
@@ -50,7 +51,7 @@ class IndexController extends BackendController
      *
      * @return string
      */
-    protected function getExtensionConfigurationUri()
+    protected function getExtensionConfigurationUri(): string
     {
         return $this->uriBuilder
             ->reset()

--- a/Classes/Controller/Backend/Administration/ShowDefinitionController.php
+++ b/Classes/Controller/Backend/Administration/ShowDefinitionController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -46,7 +47,7 @@ class ShowDefinitionController extends BackendController
     /**
      * @inheritdoc
      */
-    protected function getMenu()
+    protected function getMenu(): string
     {
         return Menu::ADMINISTRATION_DEFINITION;
     }

--- a/Classes/Controller/Backend/Administration/ShowExceptionController.php
+++ b/Classes/Controller/Backend/Administration/ShowExceptionController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -49,7 +50,7 @@ class ShowExceptionController extends BackendController
     /**
      * @inheritdoc
      */
-    protected function getMenu()
+    protected function getMenu(): string
     {
         return Menu::ADMINISTRATION_DEFINITION;
     }

--- a/Classes/Controller/Backend/BackendController.php
+++ b/Classes/Controller/Backend/BackendController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -75,7 +76,7 @@ abstract class BackendController extends ActionController
      *
      * @return string
      */
-    abstract protected function getMenu();
+    abstract protected function getMenu(): string;
 
     /**
      * If the definition contain errors, the request is forwarded. If the user
@@ -117,7 +118,7 @@ abstract class BackendController extends ActionController
      * @param string $key
      * @param mixed ...$arguments
      */
-    protected function addErrorMessage($key, ...$arguments)
+    protected function addErrorMessage(string $key, ...$arguments)
     {
         $this->addFlashMessage(
             LocalizationService::localize($key, $arguments),
@@ -129,7 +130,7 @@ abstract class BackendController extends ActionController
     /**
      * @return Definition
      */
-    protected function getDefinition()
+    protected function getDefinition(): Definition
     {
         return $this->definitionService->getDefinition();
     }

--- a/Classes/Controller/Backend/Manager/ListEventsController.php
+++ b/Classes/Controller/Backend/Manager/ListEventsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -32,7 +33,7 @@ class ListEventsController extends ManagerController
     /**
      * @return string
      */
-    protected function getMenu()
+    protected function getMenu(): string
     {
         return Menu::MANAGER_EVENTS;
     }

--- a/Classes/Controller/Backend/Manager/ListNotificationTypesController.php
+++ b/Classes/Controller/Backend/Manager/ListNotificationTypesController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -30,7 +31,7 @@ class ListNotificationTypesController extends ManagerController
     /**
      * @return string
      */
-    protected function getMenu()
+    protected function getMenu(): string
     {
         return Menu::MANAGER_NOTIFICATIONS;
     }

--- a/Classes/Controller/Backend/Manager/ListNotificationsController.php
+++ b/Classes/Controller/Backend/Manager/ListNotificationsController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -29,7 +30,7 @@ class ListNotificationsController extends ManagerController
      * @param string $notificationIdentifier
      * @param string $filterEvent
      */
-    public function processAction($notificationIdentifier, $filterEvent = null)
+    public function processAction(string $notificationIdentifier, string $filterEvent = null)
     {
         $definition = $this->getDefinition();
 
@@ -69,17 +70,17 @@ class ListNotificationsController extends ManagerController
     /**
      * @return string
      */
-    protected function getMenu()
+    protected function getMenu(): string
     {
         return Menu::MANAGER_NOTIFICATIONS;
     }
 
     /**
      * @param string $notificationIdentifier
-     * @param string|null $filterEvent
+     * @param string|null $filterEvent [PHP 7.1]
      * @return Notification[]
      */
-    private function getNotifications($notificationIdentifier, $filterEvent)
+    private function getNotifications(string $notificationIdentifier, $filterEvent): array
     {
         $definition = $this->getDefinition();
 

--- a/Classes/Controller/Backend/Manager/ManagerController.php
+++ b/Classes/Controller/Backend/Manager/ManagerController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Controller/Backend/Manager/Notification/ShowEntityEmailController.php
+++ b/Classes/Controller/Backend/Manager/Notification/ShowEntityEmailController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -50,7 +51,7 @@ class ShowEntityEmailController extends ShowNotificationController
      * by the notification. Example values may be added to simulate fake markers
      * in the view.
      *
-     * @return string
+     * @return string|null [PHP 7.1]
      */
     public function previewAction()
     {
@@ -72,7 +73,7 @@ class ShowEntityEmailController extends ShowNotificationController
     /**
      * @return string
      */
-    protected function getEmailPreview()
+    protected function getEmailPreview(): string
     {
         if (!$this->notification->hasEventDefinition()) {
             return $this->notification->getBody();
@@ -87,7 +88,7 @@ class ShowEntityEmailController extends ShowNotificationController
     /**
      * @return string
      */
-    public function getNotificationDefinitionIdentifier()
+    public function getNotificationDefinitionIdentifier(): string
     {
         return EntityEmailNotification::getDefinitionIdentifier();
     }

--- a/Classes/Controller/Backend/Manager/Notification/ShowEntityEmailController.php
+++ b/Classes/Controller/Backend/Manager/Notification/ShowEntityEmailController.php
@@ -19,7 +19,6 @@ namespace CuyZ\Notiz\Controller\Backend\Manager\Notification;
 use CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\EntityEmailNotification;
 use CuyZ\Notiz\Domain\Notification\Email\Application\EntityEmail\Service\EntityEmailTemplateBuilder;
 use CuyZ\Notiz\Domain\Property\Email;
-use Exception;
 use Throwable;
 
 class ShowEntityEmailController extends ShowNotificationController
@@ -58,11 +57,8 @@ class ShowEntityEmailController extends ShowNotificationController
         try {
             return $this->getEmailPreview();
         } catch (Throwable $e) {
-        } catch (Exception $e) {
-            // @PHP7
+            return null;
         }
-
-        return null;
     }
 
     /**

--- a/Classes/Controller/Backend/Manager/Notification/ShowEntityLogController.php
+++ b/Classes/Controller/Backend/Manager/Notification/ShowEntityLogController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -41,7 +42,7 @@ class ShowEntityLogController extends ShowNotificationController
      *
      * @return string
      */
-    protected function getPreview()
+    protected function getPreview(): string
     {
         /** @var EntityLogMessageBuilder $entityLogMessageBuilder */
         $entityLogMessageBuilder = $this->objectManager->get(EntityLogMessageBuilder::class, $this->getPreviewPayload());
@@ -52,7 +53,7 @@ class ShowEntityLogController extends ShowNotificationController
     /**
      * @return string
      */
-    public function getNotificationDefinitionIdentifier()
+    public function getNotificationDefinitionIdentifier(): string
     {
         return EntityLogNotification::getDefinitionIdentifier();
     }

--- a/Classes/Controller/Backend/Manager/Notification/ShowEntitySlackController.php
+++ b/Classes/Controller/Backend/Manager/Notification/ShowEntitySlackController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -52,7 +53,7 @@ class ShowEntitySlackController extends ShowNotificationController
     /**
      * @return string
      */
-    public function getNotificationDefinitionIdentifier()
+    public function getNotificationDefinitionIdentifier(): string
     {
         return EntitySlackNotification::getDefinitionIdentifier();
     }

--- a/Classes/Controller/Backend/Manager/Notification/ShowNotificationController.php
+++ b/Classes/Controller/Backend/Manager/Notification/ShowNotificationController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -83,7 +84,7 @@ abstract class ShowNotificationController extends ManagerController
     /**
      * @return string
      */
-    abstract public function getNotificationDefinitionIdentifier();
+    abstract public function getNotificationDefinitionIdentifier(): string;
 
     /**
      * Checks that an argument `notificationIdentifier` exists for the request,
@@ -115,7 +116,7 @@ abstract class ShowNotificationController extends ManagerController
     /**
      * @return Payload
      */
-    protected function getPreviewPayload()
+    protected function getPreviewPayload(): Payload
     {
         $fakeEvent = $this->eventFactory->create($this->notification->getEventDefinition(), $this->notification);
 
@@ -153,7 +154,7 @@ abstract class ShowNotificationController extends ManagerController
     /**
      * @return string
      */
-    protected function getMenu()
+    protected function getMenu(): string
     {
         return Menu::MANAGER_NOTIFICATIONS;
     }

--- a/Classes/Controller/Backend/Manager/NotificationActivationController.php
+++ b/Classes/Controller/Backend/Manager/NotificationActivationController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -18,7 +19,6 @@ namespace CuyZ\Notiz\Controller\Backend\Manager;
 
 use CuyZ\Notiz\Controller\Backend\Menu;
 use CuyZ\Notiz\Core\Notification\Activable;
-use TYPO3\CMS\Extbase\Mvc\Exception\StopActionException;
 
 class NotificationActivationController extends ManagerController
 {
@@ -27,7 +27,7 @@ class NotificationActivationController extends ManagerController
      * @param string $notificationIdentifier
      * @param string $filterEvent
      */
-    public function processAction($notificationType, $notificationIdentifier, $filterEvent = null)
+    public function processAction(string $notificationType, string $notificationIdentifier, string $filterEvent = null)
     {
         $definition = $this->getDefinition();
 
@@ -62,10 +62,9 @@ class NotificationActivationController extends ManagerController
 
     /**
      * @param string $notificationType
-     * @param string $filterEvent
-     * @throws StopActionException
+     * @param string|null $filterEvent [PHP 7.1]
      */
-    private function returnToList($notificationType, $filterEvent)
+    private function returnToList(string $notificationType, $filterEvent)
     {
         $this->forward(
             'process',
@@ -81,7 +80,7 @@ class NotificationActivationController extends ManagerController
     /**
      * @return string
      */
-    protected function getMenu()
+    protected function getMenu(): string
     {
         return Menu::MANAGER_NOTIFICATIONS;
     }

--- a/Classes/Controller/Backend/Manager/NotificationActivationController.php
+++ b/Classes/Controller/Backend/Manager/NotificationActivationController.php
@@ -25,7 +25,7 @@ class NotificationActivationController extends ManagerController
     /**
      * @param string $notificationType
      * @param string $notificationIdentifier
-     * @param string $filterEvent
+     * @param string|null $filterEvent
      */
     public function processAction(string $notificationType, string $notificationIdentifier, string $filterEvent = null)
     {

--- a/Classes/Controller/Backend/Manager/ShowEventController.php
+++ b/Classes/Controller/Backend/Manager/ShowEventController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -28,7 +29,7 @@ class ShowEventController extends ManagerController
      *
      * @param string $eventIdentifier
      */
-    public function processAction($eventIdentifier)
+    public function processAction(string $eventIdentifier)
     {
         $definition = $this->getDefinition();
 
@@ -59,7 +60,7 @@ class ShowEventController extends ManagerController
     /**
      * @return string
      */
-    protected function getMenu()
+    protected function getMenu(): string
     {
         return Menu::MANAGER_EVENTS;
     }

--- a/Classes/Controller/Backend/Menu.php
+++ b/Classes/Controller/Backend/Menu.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Channel/AbstractChannel.php
+++ b/Classes/Core/Channel/AbstractChannel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -132,7 +133,7 @@ abstract class AbstractChannel implements Channel
      * @param NotificationDefinition $notification
      * @return bool
      */
-    public static function supportsNotification(NotificationDefinition $notification)
+    public static function supportsNotification(NotificationDefinition $notification): bool
     {
         self::checkSupportedNotifications();
 
@@ -189,7 +190,7 @@ abstract class AbstractChannel implements Channel
      *
      * @return string
      */
-    public static function getSettingsClassName()
+    public static function getSettingsClassName(): string
     {
         /** @var ReflectionService $reflectionService */
         $reflectionService = Container::get(ReflectionService::class);

--- a/Classes/Core/Channel/Channel.php
+++ b/Classes/Core/Channel/Channel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -46,7 +47,7 @@ interface Channel
      * @param NotificationDefinition $notification
      * @return bool
      */
-    public static function supportsNotification(NotificationDefinition $notification);
+    public static function supportsNotification(NotificationDefinition $notification): bool;
 
     /**
      * Must return a class name that implements:
@@ -55,5 +56,5 @@ interface Channel
      *
      * @return string
      */
-    public static function getSettingsClassName();
+    public static function getSettingsClassName(): string;
 }

--- a/Classes/Core/Channel/Payload.php
+++ b/Classes/Core/Channel/Payload.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -71,7 +72,7 @@ class Payload
     /**
      * @return Notification
      */
-    public function getNotification()
+    public function getNotification(): Notification
     {
         return $this->notification;
     }
@@ -79,7 +80,7 @@ class Payload
     /**
      * @return NotificationDefinition
      */
-    public function getNotificationDefinition()
+    public function getNotificationDefinition(): NotificationDefinition
     {
         return $this->notificationDefinition;
     }
@@ -87,7 +88,7 @@ class Payload
     /**
      * @return Event
      */
-    public function getEvent()
+    public function getEvent(): Event
     {
         return $this->event;
     }
@@ -95,7 +96,7 @@ class Payload
     /**
      * @return NotificationProcessor
      */
-    public function getNotificationProcessor()
+    public function getNotificationProcessor(): NotificationProcessor
     {
         return $this->notificationProcessor;
     }

--- a/Classes/Core/Channel/Service/ChannelFactory.php
+++ b/Classes/Core/Channel/Service/ChannelFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -40,7 +41,7 @@ class ChannelFactory implements SingletonInterface
      * @param ChannelDefinition $channelDefinition
      * @return Channel
      */
-    public function create(ChannelDefinition $channelDefinition)
+    public function create(ChannelDefinition $channelDefinition): Channel
     {
         $settings = clone $channelDefinition->getSettings();
 

--- a/Classes/Core/Channel/Settings/ChannelSettings.php
+++ b/Classes/Core/Channel/Settings/ChannelSettings.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Channel/Settings/EmptyChannelSettings.php
+++ b/Classes/Core/Channel/Settings/EmptyChannelSettings.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Definition/Builder/Component/DefinitionComponents.php
+++ b/Classes/Core/Definition/Builder/Component/DefinitionComponents.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -70,7 +71,7 @@ class DefinitionComponents
      * @throws ClassNotFoundException
      * @throws InvalidClassException
      */
-    public function addSource($className)
+    public function addSource(string $className): DefinitionSource
     {
         if (!$this->hasSource($className)) {
             if (!class_exists($className)) {
@@ -91,7 +92,7 @@ class DefinitionComponents
      * @param string $className
      * @return bool
      */
-    public function hasSource($className)
+    public function hasSource(string $className): bool
     {
         return true === isset($this->sources[$className]);
     }
@@ -102,7 +103,7 @@ class DefinitionComponents
      *
      * @throws EntryNotFoundException
      */
-    public function getSource($className)
+    public function getSource(string $className): DefinitionSource
     {
         if (false === $this->hasSource($className)) {
             throw EntryNotFoundException::definitionSourceNotFound($className);
@@ -114,7 +115,7 @@ class DefinitionComponents
     /**
      * @return DefinitionSource[]
      */
-    public function getSources()
+    public function getSources(): array
     {
         return $this->sources;
     }
@@ -133,7 +134,7 @@ class DefinitionComponents
      * @throws ClassNotFoundException
      * @throws InvalidClassException
      */
-    public function addProcessor($className)
+    public function addProcessor(string $className): DefinitionProcessor
     {
         if (false === $this->hasProcessor($className)) {
             if (!class_exists($className)) {
@@ -154,7 +155,7 @@ class DefinitionComponents
      * @param string $className
      * @return bool
      */
-    public function hasProcessor($className)
+    public function hasProcessor(string $className): bool
     {
         return true === isset($this->processors[$className]);
     }
@@ -165,7 +166,7 @@ class DefinitionComponents
      *
      * @throws EntryNotFoundException
      */
-    public function getProcessor($className)
+    public function getProcessor(string $className): DefinitionProcessor
     {
         if (false === $this->hasProcessor($className)) {
             throw EntryNotFoundException::definitionProcessorNotFound($className);
@@ -177,7 +178,7 @@ class DefinitionComponents
     /**
      * @return DefinitionProcessor[]
      */
-    public function getProcessors()
+    public function getProcessors(): array
     {
         return $this->processors;
     }

--- a/Classes/Core/Definition/Builder/Component/Processor/DefinitionProcessor.php
+++ b/Classes/Core/Definition/Builder/Component/Processor/DefinitionProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Definition/Builder/Component/Source/DefinitionSource.php
+++ b/Classes/Core/Definition/Builder/Component/Source/DefinitionSource.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -35,5 +36,5 @@ interface DefinitionSource
      *
      * @return array
      */
-    public function getDefinitionArray();
+    public function getDefinitionArray(): array;
 }

--- a/Classes/Core/Definition/Builder/DefinitionBuilder.php
+++ b/Classes/Core/Definition/Builder/DefinitionBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -150,7 +151,7 @@ class DefinitionBuilder implements SingletonInterface
      *
      * @return ConfigurationObjectInstance
      */
-    public function buildDefinition()
+    public function buildDefinition(): ConfigurationObjectInstance
     {
         if (null === $this->definitionObject) {
             if ($this->cacheService->has(NotizConstants::CACHE_KEY_DEFINITION_OBJECT)) {
@@ -190,7 +191,7 @@ class DefinitionBuilder implements SingletonInterface
      *
      * @return ConfigurationObjectInstance
      */
-    protected function buildDefinitionInternal()
+    protected function buildDefinitionInternal(): ConfigurationObjectInstance
     {
         $arrayDefinition = [];
 

--- a/Classes/Core/Definition/DefinitionService.php
+++ b/Classes/Core/Definition/DefinitionService.php
@@ -21,7 +21,6 @@ use CuyZ\Notiz\Core\Definition\Tree\Definition;
 use CuyZ\Notiz\Core\Exception\InvalidDefinitionException;
 use CuyZ\Notiz\Service\RuntimeService;
 use CuyZ\Notiz\Service\Traits\ExtendedSelfInstantiateTrait;
-use Exception;
 use Romm\ConfigurationObject\ConfigurationObjectInstance;
 use Throwable;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -160,11 +159,6 @@ class DefinitionService implements SingletonInterface
                 $this->definitionObject = $this->builder->buildDefinition();
                 $this->validationResult = $this->definitionObject->getValidationResult();
             } catch (Throwable $exception) {
-            } catch (Exception $exception) {
-                // @PHP7
-            }
-
-            if ($exception) {
                 $this->exception = $exception;
                 $this->validationResult = new Result;
 

--- a/Classes/Core/Definition/DefinitionService.php
+++ b/Classes/Core/Definition/DefinitionService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -96,7 +97,7 @@ class DefinitionService implements SingletonInterface
     /**
      * @return Result
      */
-    public function getValidationResult()
+    public function getValidationResult(): Result
     {
         $this->buildDefinitionObject();
 
@@ -108,7 +109,7 @@ class DefinitionService implements SingletonInterface
      *
      * @throws InvalidDefinitionException
      */
-    public function getDefinition()
+    public function getDefinition(): Definition
     {
         $this->buildDefinitionObject();
 
@@ -128,7 +129,7 @@ class DefinitionService implements SingletonInterface
      *
      * @return array
      */
-    public function getDefinitionArray()
+    public function getDefinitionArray(): array
     {
         $this->buildDefinitionObject();
 

--- a/Classes/Core/Definition/DefinitionTransformer.php
+++ b/Classes/Core/Definition/DefinitionTransformer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -45,7 +46,7 @@ class DefinitionTransformer implements SingletonInterface
      *
      * @return array
      */
-    public function getDefinitionArray()
+    public function getDefinitionArray(): array
     {
         return $this->transformDefinition(
             $this->definitionService->getDefinitionArray(),
@@ -59,7 +60,7 @@ class DefinitionTransformer implements SingletonInterface
      * @param array $path
      * @return array
      */
-    protected function transformDefinition(array $definition, Result $result, array $path = [])
+    protected function transformDefinition(array $definition, Result $result, array $path = []): array
     {
         $newDefinition = [];
 

--- a/Classes/Core/Definition/Tree/AbstractDefinitionComponent.php
+++ b/Classes/Core/Definition/Tree/AbstractDefinitionComponent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -59,7 +60,7 @@ abstract class AbstractDefinitionComponent
      * @param string $property
      * @param string $name
      */
-    protected static function forceIdentifierForProperty(DataPreProcessor $processor, $property, $name = 'identifier')
+    protected static function forceIdentifierForProperty(DataPreProcessor $processor, string $property, string $name = 'identifier')
     {
         $data = $processor->getData();
         $data = is_array($data)

--- a/Classes/Core/Definition/Tree/Definition.php
+++ b/Classes/Core/Definition/Tree/Definition.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -54,7 +55,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
     /**
      * @return EventGroup[]
      */
-    public function getEventGroups()
+    public function getEventGroups(): array
     {
         return $this->eventGroups;
     }
@@ -62,7 +63,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
     /**
      * @return Generator|EventDefinition[]
      */
-    public function getEvents()
+    public function getEvents(): Generator
     {
         foreach ($this->eventGroups as $eventGroup) {
             foreach ($eventGroup->getEvents() as $event) {
@@ -75,7 +76,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
      * @param string $identifier
      * @return bool
      */
-    public function hasEventGroup($identifier)
+    public function hasEventGroup(string $identifier): bool
     {
         return true === isset($this->eventGroups[$identifier]);
     }
@@ -86,7 +87,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
      *
      * @throws EntryNotFoundException
      */
-    public function getEventGroup($identifier)
+    public function getEventGroup(string $identifier): EventGroup
     {
         if (false === $this->hasEventGroup($identifier)) {
             throw EntryNotFoundException::definitionEventGroupNotFound($identifier);
@@ -101,7 +102,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
      *
      * @throws EntryNotFoundException
      */
-    public function getEventFromFullIdentifier($fullIdentifier)
+    public function getEventFromFullIdentifier(string $fullIdentifier): EventDefinition
     {
         if (!$this->hasEventFromFullIdentifier($fullIdentifier)) {
             throw EntryNotFoundException::definitionEventFullIdentifierNotFound($fullIdentifier);
@@ -116,7 +117,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
      * @param string $fullIdentifier
      * @return bool
      */
-    public function hasEventFromFullIdentifier($fullIdentifier)
+    public function hasEventFromFullIdentifier(string $fullIdentifier): bool
     {
         list($eventGroup, $event) = explode('.', $fullIdentifier);
 
@@ -127,7 +128,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
     /**
      * @return EventGroup
      */
-    public function getFirstEventGroup()
+    public function getFirstEventGroup(): EventGroup
     {
         return array_pop(array_reverse($this->getEventGroups()));
     }
@@ -135,7 +136,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
     /**
      * @return NotificationDefinition[]
      */
-    public function getNotifications()
+    public function getNotifications(): array
     {
         return $this->notifications;
     }
@@ -143,7 +144,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
     /**
      * @return NotificationDefinition[]
      */
-    public function getListableNotifications()
+    public function getListableNotifications(): array
     {
         return array_filter(
             $this->notifications,
@@ -157,7 +158,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
      * @param $identifier
      * @return bool
      */
-    public function hasNotification($identifier)
+    public function hasNotification($identifier): bool
     {
         return true === isset($this->notifications[$identifier]);
     }
@@ -168,7 +169,7 @@ class Definition extends AbstractDefinitionComponent implements ConfigurationObj
      *
      * @throws EntryNotFoundException
      */
-    public function getNotification($identifier)
+    public function getNotification(string $identifier): NotificationDefinition
     {
         if (false === $this->hasNotification($identifier)) {
             throw EntryNotFoundException::definitionNotificationNotFound($identifier);

--- a/Classes/Core/Definition/Tree/EventGroup/Event/Configuration/EventConfiguration.php
+++ b/Classes/Core/Definition/Tree/EventGroup/Event/Configuration/EventConfiguration.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -42,7 +43,7 @@ class EventConfiguration extends AbstractDefinitionComponent implements DataPreP
     /**
      * @return EventFlexFormProvider
      */
-    public function getFlexFormProvider()
+    public function getFlexFormProvider(): EventFlexFormProvider
     {
         return $this->flexForm;
     }
@@ -83,7 +84,7 @@ class EventConfiguration extends AbstractDefinitionComponent implements DataPreP
      * @throws ClassNotFoundException
      * @throws InvalidClassException
      */
-    protected static function setFlexFormProviderClassName(array $data)
+    protected static function setFlexFormProviderClassName(array $data): array
     {
         if (isset($data['flexFormProviderClassName'])) {
             $className = $data['flexFormProviderClassName'];

--- a/Classes/Core/Definition/Tree/EventGroup/Event/Configuration/FlexForm/EventFlexFormResolver.php
+++ b/Classes/Core/Definition/Tree/EventGroup/Event/Configuration/FlexForm/EventFlexFormResolver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Definition/Tree/EventGroup/Event/Connection/Connection.php
+++ b/Classes/Core/Definition/Tree/EventGroup/Event/Connection/Connection.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Definition/Tree/EventGroup/Event/Connection/ConnectionResolver.php
+++ b/Classes/Core/Definition/Tree/EventGroup/Event/Connection/ConnectionResolver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -66,7 +67,7 @@ class ConnectionResolver implements SingletonInterface, MixedTypesInterface
      * @throws EntryNotFoundException
      * @throws InvalidTypeException
      */
-    protected static function getConnectionType(MixedTypesResolver $resolver)
+    protected static function getConnectionType(MixedTypesResolver $resolver): string
     {
         $data = $resolver->getData();
         $data = is_array($data)

--- a/Classes/Core/Definition/Tree/EventGroup/Event/Connection/Hook.php
+++ b/Classes/Core/Definition/Tree/EventGroup/Event/Connection/Hook.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -53,7 +54,7 @@ class Hook extends AbstractDefinitionComponent implements Connection
     /**
      * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }
@@ -114,7 +115,7 @@ class Hook extends AbstractDefinitionComponent implements Connection
      * @throws ClassNotFoundException
      * @throws WrongFormatException
      */
-    protected function preventEvalNeverIdealStuff(EventRunner $eventRunner)
+    protected function preventEvalNeverIdealStuff(EventRunner $eventRunner): string
     {
         $className = 'notiz_hook_' . sha1($eventRunner->getEventDefinition()->getFullIdentifier());
 
@@ -151,7 +152,7 @@ class Hook extends AbstractDefinitionComponent implements Connection
      * @param EventRunner $eventRunner
      * @return string
      */
-    protected function anotherNonUsefulSystem($className, $implements, $method, EventRunner $eventRunner)
+    protected function anotherNonUsefulSystem(string $className, string $implements, string $method, EventRunner $eventRunner): string
     {
         $eventRunnerContainerClass = EventRunnerContainer::class;
 
@@ -171,7 +172,7 @@ PHP;
     /**
      * @return bool
      */
-    protected function hookIsRegistered()
+    protected function hookIsRegistered(): bool
     {
         return ArrayUtility::isValidPath($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS'], $this->getFullPath(), '|');
     }
@@ -179,7 +180,7 @@ PHP;
     /**
      * @return string
      */
-    protected function getFullPath()
+    protected function getFullPath(): string
     {
         return $this->path . '|' . self::INTERNAL_HOOK_KEY;
     }
@@ -187,7 +188,7 @@ PHP;
     /**
      * @return TypoScriptFrontendController
      */
-    protected function getTypoScriptFrontendController()
+    protected function getTypoScriptFrontendController(): TypoScriptFrontendController
     {
         return $GLOBALS['TSFE'];
     }

--- a/Classes/Core/Definition/Tree/EventGroup/Event/Connection/Signal.php
+++ b/Classes/Core/Definition/Tree/EventGroup/Event/Connection/Signal.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -41,7 +42,7 @@ class Signal extends AbstractDefinitionComponent implements Connection
      * @param string $className
      * @param string $name
      */
-    public function __construct($className, $name)
+    public function __construct(string $className, string $name)
     {
         $this->className = $className;
         $this->name = $name;
@@ -67,7 +68,7 @@ class Signal extends AbstractDefinitionComponent implements Connection
     /**
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->className;
     }
@@ -75,7 +76,7 @@ class Signal extends AbstractDefinitionComponent implements Connection
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/Classes/Core/Definition/Tree/EventGroup/Event/EventDefinition.php
+++ b/Classes/Core/Definition/Tree/EventGroup/Event/EventDefinition.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -75,7 +76,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
      * @param string $identifier
      * @param string $className
      */
-    public function __construct($identifier, $className)
+    public function __construct(string $identifier, string $className)
     {
         $this->identifier = $identifier;
         $this->className = $className;
@@ -84,7 +85,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -95,7 +96,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
      *
      * @return string
      */
-    public function getFullIdentifier()
+    public function getFullIdentifier(): string
     {
         return $this->getGroup()->getIdentifier() . '.' . $this->identifier;
     }
@@ -103,7 +104,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
     /**
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return LocalizationService::localize($this->label);
     }
@@ -111,7 +112,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return LocalizationService::localize($this->description);
     }
@@ -119,7 +120,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
     /**
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->className;
     }
@@ -127,7 +128,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
     /**
      * @return EventConfiguration
      */
-    public function getConfiguration()
+    public function getConfiguration(): EventConfiguration
     {
         return $this->configuration;
     }
@@ -135,7 +136,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
     /**
      * @return Connection
      */
-    public function getConnection()
+    public function getConnection(): Connection
     {
         return $this->connection;
     }
@@ -143,7 +144,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
     /**
      * @return EventGroup
      */
-    public function getGroup()
+    public function getGroup(): EventGroup
     {
         /** @var EventGroup $eventGroup */
         $eventGroup = $this->getFirstParent(EventGroup::class);
@@ -156,7 +157,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
      * @param Notification $notification
      * @return PropertyDefinition
      */
-    public function getPropertyDefinition($propertyClassName, Notification $notification)
+    public function getPropertyDefinition(string $propertyClassName, Notification $notification): PropertyDefinition
     {
         return PropertyFactory::get()->getPropertyDefinition($propertyClassName, $this, $notification);
     }
@@ -166,7 +167,7 @@ class EventDefinition extends AbstractDefinitionComponent implements DataPreProc
      *
      * @return int
      */
-    public function getNotificationNumber()
+    public function getNotificationNumber(): int
     {
         $counter = 0;
 

--- a/Classes/Core/Definition/Tree/EventGroup/EventGroup.php
+++ b/Classes/Core/Definition/Tree/EventGroup/EventGroup.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -47,7 +48,7 @@ class EventGroup extends AbstractDefinitionComponent implements DataPreProcessor
     /**
      * @param string $identifier
      */
-    public function __construct($identifier)
+    public function __construct(string $identifier)
     {
         $this->identifier = $identifier;
     }
@@ -55,7 +56,7 @@ class EventGroup extends AbstractDefinitionComponent implements DataPreProcessor
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -63,7 +64,7 @@ class EventGroup extends AbstractDefinitionComponent implements DataPreProcessor
     /**
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return LocalizationService::localize($this->label);
     }
@@ -71,7 +72,7 @@ class EventGroup extends AbstractDefinitionComponent implements DataPreProcessor
     /**
      * @return EventDefinition[]
      */
-    public function getEvents()
+    public function getEvents(): array
     {
         return $this->events;
     }
@@ -80,7 +81,7 @@ class EventGroup extends AbstractDefinitionComponent implements DataPreProcessor
      * @param string $identifier
      * @return bool
      */
-    public function hasEvent($identifier)
+    public function hasEvent(string $identifier): bool
     {
         return true === isset($this->events[$identifier]);
     }
@@ -91,7 +92,7 @@ class EventGroup extends AbstractDefinitionComponent implements DataPreProcessor
      *
      * @throws EntryNotFoundException
      */
-    public function getEvent($identifier)
+    public function getEvent(string $identifier): EventDefinition
     {
         if (false === $this->hasEvent($identifier)) {
             throw EntryNotFoundException::definitionEventNotFound($identifier);
@@ -103,7 +104,7 @@ class EventGroup extends AbstractDefinitionComponent implements DataPreProcessor
     /**
      * @return EventDefinition
      */
-    public function getFirstEvent()
+    public function getFirstEvent(): EventDefinition
     {
         return array_pop(array_reverse($this->getEvents()));
     }

--- a/Classes/Core/Definition/Tree/Notification/Channel/ChannelDefinition.php
+++ b/Classes/Core/Definition/Tree/Notification/Channel/ChannelDefinition.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -59,7 +60,7 @@ class ChannelDefinition extends AbstractDefinitionComponent implements DataPrePr
     /**
      * @param string $identifier
      */
-    public function __construct($identifier)
+    public function __construct(string $identifier)
     {
         $this->identifier = $identifier;
     }
@@ -67,7 +68,7 @@ class ChannelDefinition extends AbstractDefinitionComponent implements DataPrePr
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -75,7 +76,7 @@ class ChannelDefinition extends AbstractDefinitionComponent implements DataPrePr
     /**
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->className;
     }
@@ -83,7 +84,7 @@ class ChannelDefinition extends AbstractDefinitionComponent implements DataPrePr
     /**
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return LocalizationService::localize($this->label);
     }
@@ -91,7 +92,7 @@ class ChannelDefinition extends AbstractDefinitionComponent implements DataPrePr
     /**
      * @return ChannelSettings
      */
-    public function getSettings()
+    public function getSettings(): ChannelSettings
     {
         return $this->settings;
     }
@@ -134,7 +135,7 @@ class ChannelDefinition extends AbstractDefinitionComponent implements DataPrePr
      * @throws ClassNotFoundException
      * @throws InvalidClassException
      */
-    protected static function fetchSettingsClassName(array $data)
+    protected static function fetchSettingsClassName(array $data): array
     {
         $channelClassName = $data['className'] ?? null;
 

--- a/Classes/Core/Definition/Tree/Notification/Channel/ChannelDefinition.php
+++ b/Classes/Core/Definition/Tree/Notification/Channel/ChannelDefinition.php
@@ -136,10 +136,7 @@ class ChannelDefinition extends AbstractDefinitionComponent implements DataPrePr
      */
     protected static function fetchSettingsClassName(array $data)
     {
-        // @PHP7
-        $channelClassName = isset($data['className'])
-            ? $data['className']
-            : null;
+        $channelClassName = $data['className'] ?? null;
 
         if (class_exists($channelClassName)
             && in_array(Channel::class, class_implements($channelClassName))

--- a/Classes/Core/Definition/Tree/Notification/Channel/Settings/ChannelSettingsResolver.php
+++ b/Classes/Core/Definition/Tree/Notification/Channel/Settings/ChannelSettingsResolver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -50,7 +51,7 @@ class ChannelSettingsResolver implements SingletonInterface, MixedTypesInterface
      * @param MixedTypesResolver $resolver
      * @return string
      */
-    protected static function getSettingsClassName(MixedTypesResolver $resolver)
+    protected static function getSettingsClassName(MixedTypesResolver $resolver): string
     {
         $data = $resolver->getData();
 

--- a/Classes/Core/Definition/Tree/Notification/NotificationDefinition.php
+++ b/Classes/Core/Definition/Tree/Notification/NotificationDefinition.php
@@ -226,10 +226,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
      */
     protected static function fetchSettingsClassName(array $data)
     {
-        // @PHP7
-        $notificationClassName = isset($data['className'])
-            ? $data['className']
-            : null;
+        $notificationClassName = $data['className'] ?? null;
 
         if (class_exists($notificationClassName)
             && in_array(CustomSettingsNotification::class, class_implements($notificationClassName))

--- a/Classes/Core/Definition/Tree/Notification/NotificationDefinition.php
+++ b/Classes/Core/Definition/Tree/Notification/NotificationDefinition.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -86,7 +87,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @param string $identifier
      */
-    public function __construct($identifier)
+    public function __construct(string $identifier)
     {
         $this->identifier = $identifier;
     }
@@ -94,7 +95,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -102,7 +103,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label
             ? LocalizationService::localize($this->label)
@@ -112,7 +113,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return LocalizationService::localize($this->description);
     }
@@ -120,7 +121,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @return string
      */
-    public function getClassName()
+    public function getClassName(): string
     {
         return $this->className;
     }
@@ -128,7 +129,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @return NotificationSettings
      */
-    public function getSettings()
+    public function getSettings(): NotificationSettings
     {
         return $this->settings;
     }
@@ -136,7 +137,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @return ChannelDefinition[]
      */
-    public function getChannels()
+    public function getChannels(): array
     {
         return $this->channels;
     }
@@ -144,7 +145,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @return string
      */
-    public function getIconPath()
+    public function getIconPath(): string
     {
         return $this->iconPath ?: self::DEFAULT_ICON_PATH;
     }
@@ -155,7 +156,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
      *
      * @return string
      */
-    public function getIconIdentifier()
+    public function getIconIdentifier(): string
     {
         return IconService::get()->registerNotificationIcon($this);
     }
@@ -163,7 +164,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @return NotificationProcessor
      */
-    public function getProcessor()
+    public function getProcessor(): NotificationProcessor
     {
         return NotificationProcessorFactory::get()->getFromNotificationClassName($this->getClassName());
     }
@@ -171,7 +172,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
     /**
      * @return bool
      */
-    public function isListable()
+    public function isListable(): bool
     {
         /** @var Viewable $className */
         $className = $this->getClassName();
@@ -224,7 +225,7 @@ class NotificationDefinition extends AbstractDefinitionComponent implements Data
      * @throws ClassNotFoundException
      * @throws InvalidClassException
      */
-    protected static function fetchSettingsClassName(array $data)
+    protected static function fetchSettingsClassName(array $data): array
     {
         $notificationClassName = $data['className'] ?? null;
 

--- a/Classes/Core/Definition/Tree/Notification/Settings/NotificationSettingsResolver.php
+++ b/Classes/Core/Definition/Tree/Notification/Settings/NotificationSettingsResolver.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -50,7 +51,7 @@ class NotificationSettingsResolver implements SingletonInterface, MixedTypesInte
      * @param MixedTypesResolver $resolver
      * @return string
      */
-    protected static function getSettingsClassName(MixedTypesResolver $resolver)
+    protected static function getSettingsClassName(MixedTypesResolver $resolver): string
     {
         $data = $resolver->getData();
 

--- a/Classes/Core/Event/AbstractEvent.php
+++ b/Classes/Core/Event/AbstractEvent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -156,7 +157,7 @@ abstract class AbstractEvent implements Event, HasProperties
      *
      * @throws InvalidClassException
      */
-    public static function getPropertyBuilder()
+    public static function getPropertyBuilder(): PropertyBuilder
     {
         $builderClassName = static::class . static::BUILDER_SUFFIX;
 
@@ -191,7 +192,7 @@ abstract class AbstractEvent implements Event, HasProperties
     /**
      * @return EventDefinition
      */
-    public function getDefinition()
+    public function getDefinition(): EventDefinition
     {
         return $this->eventDefinition;
     }
@@ -199,7 +200,7 @@ abstract class AbstractEvent implements Event, HasProperties
     /**
      * @return Notification
      */
-    public function getNotification()
+    public function getNotification(): Notification
     {
         return $this->notification;
     }

--- a/Classes/Core/Event/Configuration/FlexForm/DefaultEventFlexFormProvider.php
+++ b/Classes/Core/Event/Configuration/FlexForm/DefaultEventFlexFormProvider.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -33,7 +34,7 @@ class DefaultEventFlexFormProvider implements EventFlexFormProvider
     /**
      * @param string $file
      */
-    public function __construct($file = '')
+    public function __construct(string $file = '')
     {
         $this->file = $file;
     }
@@ -41,7 +42,7 @@ class DefaultEventFlexFormProvider implements EventFlexFormProvider
     /**
      * @return string
      */
-    public function getFlexFormValue()
+    public function getFlexFormValue(): string
     {
         return 'FILE:' . $this->file;
     }
@@ -49,7 +50,7 @@ class DefaultEventFlexFormProvider implements EventFlexFormProvider
     /**
      * @return bool
      */
-    public function hasFlexForm()
+    public function hasFlexForm(): bool
     {
         return !empty($this->file);
     }
@@ -57,7 +58,7 @@ class DefaultEventFlexFormProvider implements EventFlexFormProvider
     /**
      * @return string
      */
-    public function getFile()
+    public function getFile(): string
     {
         return $this->file;
     }

--- a/Classes/Core/Event/Configuration/FlexForm/EventFlexFormProvider.php
+++ b/Classes/Core/Event/Configuration/FlexForm/EventFlexFormProvider.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -33,10 +34,10 @@ interface EventFlexFormProvider
      *
      * @return string
      */
-    public function getFlexFormValue();
+    public function getFlexFormValue(): string;
 
     /**
      * @return bool
      */
-    public function hasFlexForm();
+    public function hasFlexForm(): bool;
 }

--- a/Classes/Core/Event/Event.php
+++ b/Classes/Core/Event/Event.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -92,10 +93,10 @@ interface Event
      *
      * @return EventDefinition
      */
-    public function getDefinition();
+    public function getDefinition(): EventDefinition;
 
     /**
      * @return Notification
      */
-    public function getNotification();
+    public function getNotification(): Notification;
 }

--- a/Classes/Core/Event/Exception/CancelEventDispatch.php
+++ b/Classes/Core/Event/Exception/CancelEventDispatch.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Event/Runner/EventRunner.php
+++ b/Classes/Core/Event/Runner/EventRunner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -156,7 +157,7 @@ class EventRunner
     /**
      * @return callable
      */
-    public function getCallable()
+    public function getCallable(): callable
     {
         return [$this, 'process'];
     }
@@ -164,7 +165,7 @@ class EventRunner
     /**
      * @return EventDefinition
      */
-    public function getEventDefinition()
+    public function getEventDefinition(): EventDefinition
     {
         return $this->eventDefinition;
     }
@@ -179,7 +180,7 @@ class EventRunner
      *
      * @return array
      */
-    public function __sleep()
+    public function __sleep(): array
     {
         return [];
     }

--- a/Classes/Core/Event/Runner/EventRunner.php
+++ b/Classes/Core/Event/Runner/EventRunner.php
@@ -24,7 +24,6 @@ use CuyZ\Notiz\Core\Event\Service\EventFactory;
 use CuyZ\Notiz\Core\Notification\Notification;
 use CuyZ\Notiz\Core\Notification\NotificationDispatcher;
 use CuyZ\Notiz\Service\ExtensionConfigurationService;
-use Exception;
 use Throwable;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 
@@ -140,11 +139,6 @@ class EventRunner
                 [$event, $notification]
             );
         } catch (Throwable $exception) {
-        } catch (Exception $exception) {
-            // @PHP7
-        }
-
-        if ($exception) {
             $this->signalDispatcher->dispatch(
                 self::class,
                 self::SIGNAL_EVENT_DISPATCH_ERROR,

--- a/Classes/Core/Event/Runner/EventRunnerContainer.php
+++ b/Classes/Core/Event/Runner/EventRunnerContainer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -44,7 +45,7 @@ class EventRunnerContainer implements SingletonInterface
      * @param EventDefinition $eventDefinition
      * @return EventRunner
      */
-    public function add(EventDefinition $eventDefinition)
+    public function add(EventDefinition $eventDefinition): EventRunner
     {
         $identifier = $eventDefinition->getFullIdentifier();
 
@@ -62,7 +63,7 @@ class EventRunnerContainer implements SingletonInterface
      * @param string $identifier
      * @return bool
      */
-    public function has($identifier)
+    public function has(string $identifier): bool
     {
         return isset($this->entries[$identifier]);
     }
@@ -73,7 +74,7 @@ class EventRunnerContainer implements SingletonInterface
      *
      * @throws EntryNotFoundException
      */
-    public function get($identifier)
+    public function get(string $identifier): EventRunner
     {
         if (false === $this->has($identifier)) {
             throw EntryNotFoundException::eventRunnerEntryNotFound($identifier);

--- a/Classes/Core/Event/Service/EventFactory.php
+++ b/Classes/Core/Event/Service/EventFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -54,7 +55,7 @@ class EventFactory implements SingletonInterface
      * @throws ClassNotFoundException
      * @throws InvalidClassException
      */
-    public function create(EventDefinition $eventDefinition, Notification $notification)
+    public function create(EventDefinition $eventDefinition, Notification $notification): Event
     {
         $className = $eventDefinition->getClassName();
 

--- a/Classes/Core/Event/Service/EventRegistry.php
+++ b/Classes/Core/Event/Service/EventRegistry.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Event/Support/HasNotificationData.php
+++ b/Classes/Core/Event/Support/HasNotificationData.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -59,5 +60,5 @@ interface HasNotificationData
      *
      * @return array
      */
-    public function getNotificationData();
+    public function getNotificationData(): array;
 }

--- a/Classes/Core/Event/Support/HasProperties.php
+++ b/Classes/Core/Event/Support/HasProperties.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -31,7 +32,7 @@ interface HasProperties
      *
      * @return PropertyBuilder
      */
-    public static function getPropertyBuilder();
+    public static function getPropertyBuilder(): PropertyBuilder;
 
     /**
      * Method called to fill the values of the properties that were added during

--- a/Classes/Core/Event/Support/ProvidesExampleProperties.php
+++ b/Classes/Core/Event/Support/ProvidesExampleProperties.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -45,5 +46,5 @@ interface ProvidesExampleProperties
      *
      * @return array
      */
-    public function getExampleProperties();
+    public function getExampleProperties(): array;
 }

--- a/Classes/Core/Exception/ClassNotFoundException.php
+++ b/Classes/Core/Exception/ClassNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -44,7 +45,7 @@ class ClassNotFoundException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function definitionSourceClassNotFound($className)
+    public static function definitionSourceClassNotFound(string $className): self
     {
         return self::makeNewInstance(
             self::DEFINITION_SOURCE_CLASS_NOT_FOUND,
@@ -57,7 +58,7 @@ class ClassNotFoundException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function definitionProcessorClassNotFound($className)
+    public static function definitionProcessorClassNotFound(string $className): self
     {
         return self::makeNewInstance(
             self::DEFINITION_PROCESSOR_CLASS_NOT_FOUND,
@@ -70,7 +71,7 @@ class ClassNotFoundException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function eventClassNotFound($className)
+    public static function eventClassNotFound(string $className): self
     {
         return self::makeNewInstance(
             self::EVENT_CLASS_NOT_FOUND,
@@ -84,7 +85,7 @@ class ClassNotFoundException extends NotizException
      * @param string $identifier
      * @return self
      */
-    public static function tagServicePropertyClassNotFound($propertyType, $identifier)
+    public static function tagServicePropertyClassNotFound(string $propertyType, string $identifier): self
     {
         return self::makeNewInstance(
             self::TAG_SERVICE_PROPERTY_CLASS_NOT_FOUND,
@@ -97,7 +98,7 @@ class ClassNotFoundException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function notificationClassNotFound($className)
+    public static function notificationClassNotFound(string $className): self
     {
         return self::makeNewInstance(
             self::NOTIFICATION_CLASS_NOT_FOUND,
@@ -111,7 +112,7 @@ class ClassNotFoundException extends NotizException
      * @param string $processorClassName
      * @return self
      */
-    public static function notificationProcessorClassNotFound($notificationClassName, $processorClassName)
+    public static function notificationProcessorClassNotFound(string $notificationClassName, string $processorClassName): self
     {
         return self::makeNewInstance(
             self::NOTIFICATION_PROCESSOR_CLASS_NOT_FOUND,
@@ -124,7 +125,7 @@ class ClassNotFoundException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function notificationSettingsClassNotFound($className)
+    public static function notificationSettingsClassNotFound(string $className): self
     {
         return self::makeNewInstance(
             self::NOTIFICATION_SETTINGS_CLASS_NOT_FOUND,
@@ -138,7 +139,7 @@ class ClassNotFoundException extends NotizException
      * @param Hook $hook
      * @return self
      */
-    public static function eventHookInterfaceNotFound($interface, Hook $hook)
+    public static function eventHookInterfaceNotFound(string $interface, Hook $hook): self
     {
         return self::makeNewInstance(
             self::EVENT_HOOK_INTERFACE_NOT_FOUND,
@@ -154,7 +155,7 @@ class ClassNotFoundException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function eventConfigurationFlexFormProviderClassNotFound($className)
+    public static function eventConfigurationFlexFormProviderClassNotFound(string $className): self
     {
         return self::makeNewInstance(
             self::EVENT_CONFIGURATION_FLEX_FORM_PROVIDER_CLASS_NOT_FOUND,
@@ -167,7 +168,7 @@ class ClassNotFoundException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function channelSettingsClassNotFound($className)
+    public static function channelSettingsClassNotFound(string $className): self
     {
         return self::makeNewInstance(
             self::CHANNEL_SETTINGS_CLASS_NOT_FOUND,

--- a/Classes/Core/Exception/DuplicateEntryException.php
+++ b/Classes/Core/Exception/DuplicateEntryException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -32,7 +33,7 @@ class DuplicateEntryException extends NotizException
      * @param string $propertyType
      * @return self
      */
-    public static function propertyEntryDuplication($name, $eventClassName, $propertyType)
+    public static function propertyEntryDuplication(string $name, string $eventClassName, string $propertyType): self
     {
         return self::makeNewInstance(
             self::PROPERTY_ENTRY_DUPLICATION,
@@ -47,7 +48,7 @@ class DuplicateEntryException extends NotizException
      * @param string $assignedPropertyType
      * @return self
      */
-    public static function tagServiceIdentifierDuplication($identifier, $propertyType, $assignedPropertyType)
+    public static function tagServiceIdentifierDuplication(string $identifier, string $propertyType, string $assignedPropertyType): self
     {
         return self::makeNewInstance(
             self::TAG_SERVICE_IDENTIFIER_DUPLICATION,
@@ -60,7 +61,7 @@ class DuplicateEntryException extends NotizException
      * @param string $name
      * @return self
      */
-    public static function slotContainerDuplication($name)
+    public static function slotContainerDuplication(string $name): self
     {
         return self::makeNewInstance(
             self::SLOT_CONTAINER_DUPLICATION,
@@ -74,7 +75,7 @@ class DuplicateEntryException extends NotizException
      * @param string $slot
      * @return self
      */
-    public static function markerAlreadyDefined($marker, $slot)
+    public static function markerAlreadyDefined(string $marker, string $slot): self
     {
         return self::makeNewInstance(
             self::MARKER_ALREADY_DEFINED,

--- a/Classes/Core/Exception/EntryNotFoundException.php
+++ b/Classes/Core/Exception/EntryNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -53,7 +54,7 @@ class EntryNotFoundException extends NotizException
      * @param string $identifier
      * @return self
      */
-    public static function definitionSourceNotFound($identifier)
+    public static function definitionSourceNotFound(string $identifier): self
     {
         return self::makeNewInstance(
             self::DEFINITION_SOURCE_NOT_FOUND,
@@ -66,7 +67,7 @@ class EntryNotFoundException extends NotizException
      * @param string $identifier
      * @return self
      */
-    public static function definitionProcessorNotFound($identifier)
+    public static function definitionProcessorNotFound(string $identifier): self
     {
         return self::makeNewInstance(
             self::DEFINITION_PROCESSOR_NOT_FOUND,
@@ -79,7 +80,7 @@ class EntryNotFoundException extends NotizException
      * @param string $identifier
      * @return self
      */
-    public static function definitionEventGroupNotFound($identifier)
+    public static function definitionEventGroupNotFound(string $identifier): self
     {
         return self::makeNewInstance(
             self::DEFINITION_EVENT_GROUP_NOT_FOUND,
@@ -92,7 +93,7 @@ class EntryNotFoundException extends NotizException
      * @param string $identifier
      * @return self
      */
-    public static function definitionEventNotFound($identifier)
+    public static function definitionEventNotFound(string $identifier): self
     {
         return self::makeNewInstance(
             self::DEFINITION_EVENT_NOT_FOUND,
@@ -105,7 +106,7 @@ class EntryNotFoundException extends NotizException
      * @param string $fullIdentifier
      * @return self
      */
-    public static function definitionEventFullIdentifierNotFound($fullIdentifier)
+    public static function definitionEventFullIdentifierNotFound(string $fullIdentifier): self
     {
         return self::makeNewInstance(
             self::DEFINITION_EVENT_FULL_IDENTIFIER_NOT_FOUND,
@@ -118,7 +119,7 @@ class EntryNotFoundException extends NotizException
      * @param string $identifier
      * @return self
      */
-    public static function definitionNotificationNotFound($identifier)
+    public static function definitionNotificationNotFound(string $identifier): self
     {
         return self::makeNewInstance(
             self::DEFINITION_NOTIFICATION_NOT_FOUND,
@@ -131,7 +132,7 @@ class EntryNotFoundException extends NotizException
      * @param string $identifier
      * @return self
      */
-    public static function entityEmailViewLayoutNotFound($identifier)
+    public static function entityEmailViewLayoutNotFound(string $identifier): self
     {
         return self::makeNewInstance(
             self::ENTITY_EMAIL_VIEW_LAYOUT_NOT_FOUND,
@@ -147,7 +148,7 @@ class EntryNotFoundException extends NotizException
      * @param object $object
      * @return self
      */
-    public static function propertyEntryNotFound($name, $eventClassName, $propertyType, $object)
+    public static function propertyEntryNotFound(string $name, string $eventClassName, string $propertyType, $object): self
     {
         return self::makeNewInstance(
             self::PROPERTY_ENTRY_NOT_FOUND,
@@ -160,7 +161,7 @@ class EntryNotFoundException extends NotizException
      * @param string $key
      * @return self
      */
-    public static function extensionConfigurationEntryNotFound($key)
+    public static function extensionConfigurationEntryNotFound(string $key): self
     {
         return self::makeNewInstance(
             self::EXTENSION_CONFIGURATION_ENTRY_NOT_FOUND,
@@ -173,7 +174,7 @@ class EntryNotFoundException extends NotizException
      * @param string $key
      * @return self
      */
-    public static function eventRunnerEntryNotFound($key)
+    public static function eventRunnerEntryNotFound(string $key): self
     {
         return self::makeNewInstance(
             self::EVENT_RUNNER_ENTRY_NOT_FOUND,
@@ -186,7 +187,7 @@ class EntryNotFoundException extends NotizException
      * @param array $allowedTypes
      * @return self
      */
-    public static function eventConnectionTypeMissing(array $allowedTypes)
+    public static function eventConnectionTypeMissing(array $allowedTypes): self
     {
         return self::makeNewInstance(
             self::EVENT_CONNECTION_TYPE_MISSING,
@@ -199,7 +200,7 @@ class EntryNotFoundException extends NotizException
      * @param string $botIdentifier
      * @return self
      */
-    public static function entitySlackBotNotFound($botIdentifier)
+    public static function entitySlackBotNotFound(string $botIdentifier): self
     {
         return self::makeNewInstance(
             self::ENTITY_SLACK_BOT_NOT_FOUND,
@@ -212,7 +213,7 @@ class EntryNotFoundException extends NotizException
      * @param string $identifier
      * @return self
      */
-    public static function entitySlackChannelDefinitionNotFound($identifier)
+    public static function entitySlackChannelDefinitionNotFound(string $identifier): self
     {
         return self::makeNewInstance(
             self::ENTITY_SLACK_CHANNEL_DEFINITION_NOT_FOUND,

--- a/Classes/Core/Exception/FileNotFoundException.php
+++ b/Classes/Core/Exception/FileNotFoundException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -24,7 +25,7 @@ class FileNotFoundException extends NotizException
      * @param string $filePath
      * @return self
      */
-    public static function definitionSourceFileNotFound($filePath)
+    public static function definitionSourceFileNotFound(string $filePath): self
     {
         return self::makeNewInstance(
             self::DEFINITION_SOURCE_FILE_NOT_FOUND,

--- a/Classes/Core/Exception/InvalidClassException.php
+++ b/Classes/Core/Exception/InvalidClassException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -53,7 +54,7 @@ class InvalidClassException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function definitionSourceHasMissingInterface($className)
+    public static function definitionSourceHasMissingInterface(string $className): self
     {
         return self::makeNewInstance(
             self::DEFINITION_SOURCE_MISSING_INTERFACE,
@@ -66,7 +67,7 @@ class InvalidClassException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function definitionProcessorHasMissingInterface($className)
+    public static function definitionProcessorHasMissingInterface(string $className): self
     {
         return self::makeNewInstance(
             self::DEFINITION_PROCESSOR_MISSING_INTERFACE,
@@ -79,7 +80,7 @@ class InvalidClassException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function eventHasMissingInterface($className)
+    public static function eventHasMissingInterface(string $className): self
     {
         return self::makeNewInstance(
             self::EVENT_CLASS_MISSING_INTERFACE,
@@ -93,7 +94,7 @@ class InvalidClassException extends NotizException
      * @param string $identifier
      * @return self
      */
-    public static function tagServicePropertyWrongParent($propertyType, $identifier)
+    public static function tagServicePropertyWrongParent(string $propertyType, string $identifier): self
     {
         return self::makeNewInstance(
             self::TAG_SERVICE_PROPERTY_WRONG_PARENT,
@@ -106,7 +107,7 @@ class InvalidClassException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function notificationMissingInterface($className)
+    public static function notificationMissingInterface(string $className): self
     {
         return self::makeNewInstance(
             self::NOTIFICATION_MISSING_INTERFACE,
@@ -120,7 +121,7 @@ class InvalidClassException extends NotizException
      * @param string $processorClassName
      * @return self
      */
-    public static function notificationProcessorWrongParent($notificationClassName, $processorClassName)
+    public static function notificationProcessorWrongParent(string $notificationClassName, string $processorClassName): self
     {
         return self::makeNewInstance(
             self::NOTIFICATION_PROCESSOR_WRONG_PARENT,
@@ -133,7 +134,7 @@ class InvalidClassException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function notificationSettingsMissingInterface($className)
+    public static function notificationSettingsMissingInterface(string $className): self
     {
         return self::makeNewInstance(
             self::NOTIFICATION_SETTINGS_MISSING_INTERFACE,
@@ -146,7 +147,7 @@ class InvalidClassException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function eventConfigurationFlexFormProviderMissingInterface($className)
+    public static function eventConfigurationFlexFormProviderMissingInterface(string $className): self
     {
         return self::makeNewInstance(
             self::EVENT_CONFIGURATION_FLEX_FORM_PROVIDER_MISSING_INTERFACE,
@@ -159,7 +160,7 @@ class InvalidClassException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function channelSettingsMissingInterface($className)
+    public static function channelSettingsMissingInterface(string $className): self
     {
         return self::makeNewInstance(
             self::CHANNEL_SETTINGS_MISSING_INTERFACE,
@@ -172,7 +173,7 @@ class InvalidClassException extends NotizException
      * @param string $className
      * @return self
      */
-    public static function eventPropertyBuilderMissingInterface($className)
+    public static function eventPropertyBuilderMissingInterface(string $className): self
     {
         return self::makeNewInstance(
             self::EVENT_PROPERTY_BUILDER_MISSING_INTERFACE,

--- a/Classes/Core/Exception/InvalidDefinitionException.php
+++ b/Classes/Core/Exception/InvalidDefinitionException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -25,7 +26,7 @@ class InvalidDefinitionException extends NotizException
     /**
      * @return self
      */
-    public static function definitionErrorNoAccess()
+    public static function definitionErrorNoAccess(): self
     {
         return self::makeNewInstance(
             self::DEFINITION_ERROR_NO_ACCESS,

--- a/Classes/Core/Exception/InvalidTypeException.php
+++ b/Classes/Core/Exception/InvalidTypeException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -40,7 +41,7 @@ class InvalidTypeException extends NotizException
      * @param mixed $notifications
      * @return self
      */
-    public static function notificationContainerArrayInvalidType($notifications)
+    public static function notificationContainerArrayInvalidType($notifications): self
     {
         return self::makeNewInstance(
             self::NOTIFICATION_CONTAINER_ARRAY_INVALID_TYPE,
@@ -55,7 +56,7 @@ class InvalidTypeException extends NotizException
      * @param NotificationDefinition $notificationDefinition
      * @return self
      */
-    public static function notificationContainerEntryInvalidType($key, $notification, NotificationDefinition $notificationDefinition)
+    public static function notificationContainerEntryInvalidType(string $key, $notification, NotificationDefinition $notificationDefinition): self
     {
         return self::makeNewInstance(
             self::NOTIFICATION_CONTAINER_ENTRY_INVALID_TYPE,
@@ -72,7 +73,7 @@ class InvalidTypeException extends NotizException
      * @param string $channelClassName
      * @return self
      */
-    public static function channelSupportedNotificationsWrongType($channelClassName)
+    public static function channelSupportedNotificationsWrongType(string $channelClassName): self
     {
         return self::makeNewInstance(
             self::CHANNEL_SUPPORTED_NOTIFICATIONS_WRONG_TYPE,
@@ -86,7 +87,7 @@ class InvalidTypeException extends NotizException
      * @param array $invalidListEntries
      * @return self
      */
-    public static function channelSupportedNotificationsInvalidListEntries($channelClassName, array $invalidListEntries)
+    public static function channelSupportedNotificationsInvalidListEntries(string $channelClassName, array $invalidListEntries): self
     {
         return self::makeNewInstance(
             self::CHANNEL_SUPPORTED_NOTIFICATIONS_INVALID_LIST_ENTRIES,
@@ -103,7 +104,7 @@ class InvalidTypeException extends NotizException
      * @param NotificationDefinition $notification
      * @return self
      */
-    public static function channelUnsupportedNotificationDispatched(Channel $channel, NotificationDefinition $notification)
+    public static function channelUnsupportedNotificationDispatched(Channel $channel, NotificationDefinition $notification): self
     {
         return self::makeNewInstance(
             self::CHANNEL_UNSUPPORTED_NOTIFICATION_DISPATCHED,
@@ -119,7 +120,7 @@ class InvalidTypeException extends NotizException
      * @param mixed $value
      * @return self
      */
-    public static function definitionValidationWrongType($value)
+    public static function definitionValidationWrongType($value): self
     {
         return self::makeNewInstance(
             self::DEFINITION_VALIDATION_WRONG_TYPE,
@@ -136,7 +137,7 @@ class InvalidTypeException extends NotizException
      * @param array $allowedTypes
      * @return self
      */
-    public static function eventConnectionWrongType($type, array $allowedTypes)
+    public static function eventConnectionWrongType(string $type, array $allowedTypes): self
     {
         return self::makeNewInstance(
             self::EVENT_CONNECTION_WRONG_TYPE,

--- a/Classes/Core/Exception/NotImplementedException.php
+++ b/Classes/Core/Exception/NotImplementedException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -24,7 +25,7 @@ class NotImplementedException extends NotizException
      * @param string $methodName
      * @return self
      */
-    public static function tcaServiceNotificationIdentifierMissing($methodName)
+    public static function tcaServiceNotificationIdentifierMissing(string $methodName): self
     {
         return self::makeNewInstance(
             self::TCA_SERVICE_NOTIFICATION_IDENTIFIER_MISSING,

--- a/Classes/Core/Exception/NotizException.php
+++ b/Classes/Core/Exception/NotizException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -22,11 +23,11 @@ abstract class NotizException extends Exception
 {
     /**
      * @param string $message
-     * @param string $code
+     * @param int $code
      * @param array $arguments
      * @return static
      */
-    protected static function makeNewInstance($message, $code, array $arguments = [])
+    protected static function makeNewInstance(string $message, int $code, array $arguments = []): self
     {
         return new static(vsprintf($message, $arguments), $code);
     }

--- a/Classes/Core/Exception/PropertyNotAccessibleException.php
+++ b/Classes/Core/Exception/PropertyNotAccessibleException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -27,7 +28,7 @@ class PropertyNotAccessibleException extends NotizException
      * @param PropertyEntry $propertyEntry
      * @return self
      */
-    public static function propertyEntryValueNotAccessible(PropertyEntry $propertyEntry)
+    public static function propertyEntryValueNotAccessible(PropertyEntry $propertyEntry): self
     {
         return self::makeNewInstance(
             self::PROPERTY_ENTRY_VALUE_NOT_ACCESSIBLE,

--- a/Classes/Core/Exception/WrongFormatException.php
+++ b/Classes/Core/Exception/WrongFormatException.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -33,7 +34,7 @@ class WrongFormatException extends NotizException
      * @param string $rules
      * @return self
      */
-    public static function tagServiceIdentifierWrongFormat($propertyType, $identifier, $suggestion, $rules)
+    public static function tagServiceIdentifierWrongFormat(string $propertyType, string $identifier, string $suggestion, string $rules): self
     {
         return self::makeNewInstance(
             self::TAG_SERVICE_IDENTIFIER_WRONG_FORMAT,
@@ -47,7 +48,7 @@ class WrongFormatException extends NotizException
      * @param Hook $hook
      * @return self
      */
-    public static function eventHookMethodNameWrongFormat($methodName, Hook $hook)
+    public static function eventHookMethodNameWrongFormat(string $methodName, Hook $hook): self
     {
         return self::makeNewInstance(
             self::EVENT_HOOK_METHOD_NAME_WRONG_FORMAT,
@@ -60,7 +61,7 @@ class WrongFormatException extends NotizException
      * @param string $name
      * @return self
      */
-    public static function slotNameWrongFormat($name)
+    public static function slotNameWrongFormat(string $name): self
     {
         return self::makeNewInstance(
             self::SLOT_NAME_WRONG_FORMAT,

--- a/Classes/Core/Notification/Activable.php
+++ b/Classes/Core/Notification/Activable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -23,11 +24,11 @@ interface Activable
     /**
      * @return bool
      */
-    public function isActive();
+    public function isActive(): bool;
 
     /**
-     * @param EventDefinition|null $eventDefinition
+     * @param EventDefinition|null $eventDefinition [PHP 7.1]
      * @return string
      */
-    public function getSwitchActivationUri(EventDefinition $eventDefinition = null);
+    public function getSwitchActivationUri(EventDefinition $eventDefinition = null): string;
 }

--- a/Classes/Core/Notification/Container/NotificationContainer.php
+++ b/Classes/Core/Notification/Container/NotificationContainer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -47,7 +48,7 @@ class NotificationContainer
      * @param EventDefinition $eventDefinition
      * @return Generator
      */
-    public function fetchFromEventDefinition(EventDefinition $eventDefinition)
+    public function fetchFromEventDefinition(EventDefinition $eventDefinition): Generator
     {
         $processor = $this->notificationDefinition->getProcessor();
         $notifications = $processor->getNotificationsFromEventDefinition($eventDefinition);
@@ -61,7 +62,7 @@ class NotificationContainer
      *
      * @return Generator
      */
-    public function fetchAll()
+    public function fetchAll(): Generator
     {
         $processor = $this->notificationDefinition->getProcessor();
         $notifications = $processor->getAllNotifications();
@@ -78,7 +79,7 @@ class NotificationContainer
      *
      * @throws InvalidTypeException
      */
-    protected function loop($notifications)
+    protected function loop($notifications): Generator
     {
         if (!is_array($notifications)) {
             throw InvalidTypeException::notificationContainerArrayInvalidType($notifications);

--- a/Classes/Core/Notification/Creatable.php
+++ b/Classes/Core/Notification/Creatable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -25,11 +26,11 @@ interface Creatable
     /**
      * @return bool
      */
-    public static function isCreatable();
+    public static function isCreatable(): bool;
 
     /**
      * @param string $selectedEvent
      * @return string
      */
-    public static function getCreationUri($selectedEvent = null);
+    public static function getCreationUri(string $selectedEvent = null): string;
 }

--- a/Classes/Core/Notification/CustomSettingsNotification.php
+++ b/Classes/Core/Notification/CustomSettingsNotification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -29,5 +30,5 @@ interface CustomSettingsNotification
      *
      * @return string
      */
-    public static function getSettingsClassName();
+    public static function getSettingsClassName(): string;
 }

--- a/Classes/Core/Notification/Editable.php
+++ b/Classes/Core/Notification/Editable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -25,10 +26,10 @@ interface Editable
     /**
      * @return bool
      */
-    public function isEditable();
+    public function isEditable(): bool;
 
     /**
      * @return string
      */
-    public function getEditionUri();
+    public function getEditionUri(): string;
 }

--- a/Classes/Core/Notification/MultipleChannelsNotification.php
+++ b/Classes/Core/Notification/MultipleChannelsNotification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -38,5 +39,5 @@ interface MultipleChannelsNotification
      * @param ChannelDefinition $definition
      * @return bool
      */
-    public function shouldDispatch(ChannelDefinition $definition);
+    public function shouldDispatch(ChannelDefinition $definition): bool;
 }

--- a/Classes/Core/Notification/Notification.php
+++ b/Classes/Core/Notification/Notification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -27,6 +28,8 @@ use CuyZ\Notiz\Core\Exception\EntryNotFoundException;
 interface Notification
 {
     /**
+     * [PHP 7.1]
+     *
      * @return string|null
      */
     public function getTitle();
@@ -38,17 +41,17 @@ interface Notification
      *
      * @return string
      */
-    public static function getProcessorClassName();
+    public static function getProcessorClassName(): string;
 
     /**
      * @return NotificationDefinition
      */
-    public function getNotificationDefinition();
+    public function getNotificationDefinition(): NotificationDefinition;
 
     /**
      * @return bool
      */
-    public function hasEventDefinition();
+    public function hasEventDefinition(): bool;
 
     /**
      * Must return the event definition this notification is bound to.
@@ -57,7 +60,7 @@ interface Notification
      *
      * @throws EntryNotFoundException
      */
-    public function getEventDefinition();
+    public function getEventDefinition(): EventDefinition;
 
     /**
      * Must return a configuration array that will be used by the event during
@@ -68,5 +71,5 @@ interface Notification
      *
      * @return array
      */
-    public function getEventConfiguration();
+    public function getEventConfiguration(): array;
 }

--- a/Classes/Core/Notification/NotificationDispatcher.php
+++ b/Classes/Core/Notification/NotificationDispatcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -59,7 +60,7 @@ class NotificationDispatcher implements SingletonInterface
      * @param EventDefinition $eventDefinition
      * @return Generator
      */
-    public function fetchNotifications(EventDefinition $eventDefinition)
+    public function fetchNotifications(EventDefinition $eventDefinition): Generator
     {
         $notificationTypes = $this->definition->getNotifications();
 
@@ -79,7 +80,7 @@ class NotificationDispatcher implements SingletonInterface
      * @param NotificationDefinition $notificationDefinition
      * @return Closure
      */
-    protected function getDispatchCallback(Notification $notification, NotificationDefinition $notificationDefinition)
+    protected function getDispatchCallback(Notification $notification, NotificationDefinition $notificationDefinition): Closure
     {
         return function (Event $event) use ($notification, $notificationDefinition) {
             /** @var Payload $payload */
@@ -103,7 +104,7 @@ class NotificationDispatcher implements SingletonInterface
      * @param NotificationDefinition $notificationDefinition
      * @return NotificationContainer
      */
-    protected function getNotificationContainer(NotificationDefinition $notificationDefinition)
+    protected function getNotificationContainer(NotificationDefinition $notificationDefinition): NotificationContainer
     {
         /** @var NotificationContainer $notificationContainer */
         $notificationContainer = GeneralUtility::makeInstance(NotificationContainer::class, $notificationDefinition);
@@ -119,7 +120,7 @@ class NotificationDispatcher implements SingletonInterface
      * @param NotificationDefinition $definition
      * @return ChannelDefinition[]
      */
-    protected function getChannels(Notification $notification, NotificationDefinition $definition)
+    protected function getChannels(Notification $notification, NotificationDefinition $definition): array
     {
         if ($notification instanceof MultipleChannelsNotification) {
             /*

--- a/Classes/Core/Notification/Processor/EntityNotificationProcessor.php
+++ b/Classes/Core/Notification/Processor/EntityNotificationProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -35,7 +36,7 @@ abstract class EntityNotificationProcessor extends NotificationProcessor
      * @param EventDefinition $definition
      * @return Notification[]
      */
-    public function getNotificationsFromEventDefinition(EventDefinition $definition)
+    public function getNotificationsFromEventDefinition(EventDefinition $definition): array
     {
         return $this->notificationRepository
             ->findFromEventDefinition($definition)
@@ -46,7 +47,7 @@ abstract class EntityNotificationProcessor extends NotificationProcessor
      * @param EventDefinition $definition
      * @return Notification[]
      */
-    public function getNotificationsFromEventDefinitionWithDisabled(EventDefinition $definition)
+    public function getNotificationsFromEventDefinitionWithDisabled(EventDefinition $definition): array
     {
         return $this->notificationRepository
             ->findFromEventDefinitionWithDisabled($definition)
@@ -57,16 +58,16 @@ abstract class EntityNotificationProcessor extends NotificationProcessor
      * @param EventDefinition $definition
      * @return int
      */
-    public function countNotificationsFromEventDefinition(EventDefinition $definition)
+    public function countNotificationsFromEventDefinition(EventDefinition $definition): int
     {
         return $this->notificationRepository->countFromEventDefinition($definition);
     }
 
     /**
      * @param string $identifier
-     * @return Notification|object
+     * @return Notification
      */
-    public function getNotificationFromIdentifier($identifier)
+    public function getNotificationFromIdentifier(string $identifier): Notification
     {
         return $this->notificationRepository->findByIdentifierForce($identifier);
     }
@@ -74,7 +75,7 @@ abstract class EntityNotificationProcessor extends NotificationProcessor
     /**
      * @return Notification[]
      */
-    public function getAllNotifications()
+    public function getAllNotifications(): array
     {
         return $this->notificationRepository
             ->findAll()
@@ -84,7 +85,7 @@ abstract class EntityNotificationProcessor extends NotificationProcessor
     /**
      * @return Notification[]
      */
-    public function getAllNotificationsWithDisabled()
+    public function getAllNotificationsWithDisabled(): array
     {
         return $this->notificationRepository
             ->findAllWithDisabled()
@@ -94,7 +95,7 @@ abstract class EntityNotificationProcessor extends NotificationProcessor
     /**
      * @return int
      */
-    public function getTotalNumber()
+    public function getTotalNumber(): int
     {
         return $this->notificationRepository
             ->findAll()

--- a/Classes/Core/Notification/Processor/NotificationProcessor.php
+++ b/Classes/Core/Notification/Processor/NotificationProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -49,7 +50,7 @@ abstract class NotificationProcessor
      *
      * @param string $notificationClassName
      */
-    public function __construct($notificationClassName)
+    public function __construct(string $notificationClassName)
     {
         $this->notificationClassName = $notificationClassName;
     }
@@ -61,44 +62,44 @@ abstract class NotificationProcessor
      * @param EventDefinition $eventDefinition
      * @return Notification[]
      */
-    abstract public function getNotificationsFromEventDefinition(EventDefinition $eventDefinition);
+    abstract public function getNotificationsFromEventDefinition(EventDefinition $eventDefinition): array;
 
     /**
      * @param EventDefinition $eventDefinition
      * @return Notification[]
      */
-    abstract public function getNotificationsFromEventDefinitionWithDisabled(EventDefinition $eventDefinition);
+    abstract public function getNotificationsFromEventDefinitionWithDisabled(EventDefinition $eventDefinition): array;
 
     /**
      * @param EventDefinition $eventDefinition
      * @return int
      */
-    abstract public function countNotificationsFromEventDefinition(EventDefinition $eventDefinition);
+    abstract public function countNotificationsFromEventDefinition(EventDefinition $eventDefinition): int;
 
     /**
      * @param string $identifier
      * @return Notification
      */
-    abstract public function getNotificationFromIdentifier($identifier);
+    abstract public function getNotificationFromIdentifier(string $identifier): Notification;
 
     /**
      * Returns all notification instances.
      *
      * @return Notification[]
      */
-    abstract public function getAllNotifications();
+    abstract public function getAllNotifications(): array;
 
     /**
      * Returns all notification instances, including disabled ones.
      *
      * @return Notification[]
      */
-    abstract public function getAllNotificationsWithDisabled();
+    abstract public function getAllNotificationsWithDisabled(): array;
 
     /**
      * @return int
      */
-    abstract public function getTotalNumber();
+    abstract public function getTotalNumber(): int;
 
     /**
      * @param Activable $notification

--- a/Classes/Core/Notification/Processor/NotificationProcessorFactory.php
+++ b/Classes/Core/Notification/Processor/NotificationProcessorFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -57,7 +58,7 @@ class NotificationProcessorFactory implements SingletonInterface
      * @param Notification $notification
      * @return NotificationProcessor
      */
-    public function getFromNotification(Notification $notification)
+    public function getFromNotification(Notification $notification): NotificationProcessor
     {
         return $this->getFromNotificationClassName(get_class($notification));
     }
@@ -69,7 +70,7 @@ class NotificationProcessorFactory implements SingletonInterface
      * @throws ClassNotFoundException
      * @throws InvalidClassException
      */
-    public function getFromNotificationClassName($className)
+    public function getFromNotificationClassName(string $className): NotificationProcessor
     {
         $className = $this->objectContainer->getImplementationClassName($className);
 
@@ -97,7 +98,7 @@ class NotificationProcessorFactory implements SingletonInterface
      * @throws ClassNotFoundException
      * @throws InvalidClassException
      */
-    protected function getProcessorClassNameFromNotificationClassName($notificationClassName)
+    protected function getProcessorClassNameFromNotificationClassName(string $notificationClassName): string
     {
         /** @var Notification $notificationClassName */
         $processorClassName = $notificationClassName::getProcessorClassName();

--- a/Classes/Core/Notification/Service/NotificationTcaService.php
+++ b/Classes/Core/Notification/Service/NotificationTcaService.php
@@ -119,7 +119,6 @@ abstract class NotificationTcaService implements SingletonInterface
         $event = $definition->getFirstEventGroup()->getFirstEvent();
 
         if (isset($row['event'])) {
-            // @PHP7
             $eventValue = is_array($row['event'])
                 ? $row['event'][0]
                 : $row['event'];

--- a/Classes/Core/Notification/Service/NotificationTcaService.php
+++ b/Classes/Core/Notification/Service/NotificationTcaService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -111,7 +112,7 @@ abstract class NotificationTcaService implements SingletonInterface
      * @param array $row
      * @return EventDefinition
      */
-    protected function getSelectedEvent(array $row)
+    protected function getSelectedEvent(array $row): EventDefinition
     {
         $definition = $this->getDefinition();
 
@@ -138,7 +139,7 @@ abstract class NotificationTcaService implements SingletonInterface
      * @param array $parameters
      * @return string
      */
-    public function getMarkersLabel(array &$parameters)
+    public function getMarkersLabel(array &$parameters): string
     {
         if ($this->definitionHasErrors()) {
             return '';
@@ -201,13 +202,13 @@ HTML;
      * @param array $row
      * @return Notification
      */
-    protected function getNotification(array $row)
+    protected function getNotification(array $row): Notification
     {
         $hash = json_encode($row);
 
         if (!isset($this->notification[$hash])) {
             $this->notification[$hash] = isset($row['uid']) && is_integer($row['uid'])
-                ? $this->getNotificationDefinition()->getProcessor()->getNotificationFromIdentifier($row['uid'])
+                ? $this->getNotificationDefinition()->getProcessor()->getNotificationFromIdentifier((string)$row['uid'])
                 : reset($this->dataMapper->map($this->getNotificationDefinition()->getClassName(), [$row]));
         }
 
@@ -226,7 +227,7 @@ HTML;
     /**
      * @return string
      */
-    public function getNotificationIconPath()
+    public function getNotificationIconPath(): string
     {
         if ($this->definitionService->getValidationResult()->hasErrors()) {
             return NotizConstants::EXTENSION_ICON_DEFAULT;
@@ -238,7 +239,7 @@ HTML;
     /**
      * @return Definition
      */
-    public function getDefinition()
+    public function getDefinition(): Definition
     {
         return $this->definitionService->getDefinition();
     }
@@ -246,7 +247,7 @@ HTML;
     /**
      * @return NotificationDefinition
      */
-    protected function getNotificationDefinition()
+    protected function getNotificationDefinition(): NotificationDefinition
     {
         return $this->getDefinition()->getNotification($this->getDefinitionIdentifier());
     }
@@ -258,7 +259,7 @@ HTML;
      * @return string
      * @throws NotImplementedException
      */
-    protected function getDefinitionIdentifier()
+    protected function getDefinitionIdentifier(): string
     {
         throw NotImplementedException::tcaServiceNotificationIdentifierMissing(__METHOD__);
     }
@@ -266,7 +267,7 @@ HTML;
     /**
      * @return bool
      */
-    public function definitionHasErrors()
+    public function definitionHasErrors(): bool
     {
         return $this->definitionService->getValidationResult()->hasErrors();
     }

--- a/Classes/Core/Notification/Settings/EmptyNotificationSettings.php
+++ b/Classes/Core/Notification/Settings/EmptyNotificationSettings.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Notification/Settings/NotificationSettings.php
+++ b/Classes/Core/Notification/Settings/NotificationSettings.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Notification/TCA/EntityTcaWriter.php
+++ b/Classes/Core/Notification/TCA/EntityTcaWriter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -66,7 +67,7 @@ abstract class EntityTcaWriter implements SingletonInterface
      *
      * @return array
      */
-    abstract protected function buildTcaArray();
+    abstract protected function buildTcaArray(): array;
 
     /**
      * This method builds a TCA array and returns it to be used in a
@@ -75,7 +76,7 @@ abstract class EntityTcaWriter implements SingletonInterface
      * @param string $tableName
      * @return array
      */
-    final public function getTcaArray($tableName)
+    final public function getTcaArray(string $tableName): array
     {
         $this->tableName = $tableName;
 
@@ -97,21 +98,21 @@ abstract class EntityTcaWriter implements SingletonInterface
      *
      * @return string
      */
-    abstract protected function getNotificationTcaServiceClass();
+    abstract protected function getNotificationTcaServiceClass(): string;
 
     /**
      * Returns the title of the entity, can be a LLL reference.
      *
      * @return string
      */
-    abstract protected function getEntityTitle();
+    abstract protected function getEntityTitle(): string;
 
     /**
      * This method returns the LLL string to use for the `channel` column.
      *
      * @return string
      */
-    protected function getChannelLabel()
+    protected function getChannelLabel(): string
     {
         return self::LLL . ':field.channel';
     }
@@ -119,7 +120,7 @@ abstract class EntityTcaWriter implements SingletonInterface
     /**
      * @return array
      */
-    protected function getDefaultCtrl()
+    protected function getDefaultCtrl(): array
     {
         return [
             'title' => $this->getEntityTitle(),

--- a/Classes/Core/Notification/TCA/Processor/BodySlotsProcessor.php
+++ b/Classes/Core/Notification/TCA/Processor/BodySlotsProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -57,7 +58,7 @@ class BodySlotsProcessor extends GracefulProcessor
     /**
      * @param string $tableName
      */
-    public function doProcess($tableName)
+    public function doProcess(string $tableName)
     {
         $GLOBALS['TCA'][$tableName]['columns'][self::COLUMN]['displayCond'] = $this->getMailBodyDisplayCond();
         $GLOBALS['TCA'][$tableName]['columns'][self::COLUMN]['config']['ds'] = $this->getMailBodyFlexFormList();
@@ -72,7 +73,7 @@ class BodySlotsProcessor extends GracefulProcessor
      *
      * @return array
      */
-    private function getMailBodyDisplayCond()
+    private function getMailBodyDisplayCond(): array
     {
         $eventsWithoutSlots = [];
         $events = $this->slotViewService->getEventsWithoutSlots($this->getNotificationSettings()->getView());
@@ -92,7 +93,7 @@ class BodySlotsProcessor extends GracefulProcessor
     /**
      * @return array
      */
-    private function getMailBodyFlexFormList()
+    private function getMailBodyFlexFormList(): array
     {
         $viewSettings = $this->getNotificationSettings()->getView();
 
@@ -102,7 +103,7 @@ class BodySlotsProcessor extends GracefulProcessor
     /**
      * @return EntityEmailSettings|NotificationSettings
      */
-    private function getNotificationSettings()
+    private function getNotificationSettings(): EntityEmailSettings
     {
         return $this->definitionService
             ->getDefinition()

--- a/Classes/Core/Notification/TCA/Processor/EventConfigurationProcessor.php
+++ b/Classes/Core/Notification/TCA/Processor/EventConfigurationProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -30,7 +31,7 @@ class EventConfigurationProcessor extends GracefulProcessor
     /**
      * @param string $tableName
      */
-    protected function doProcess($tableName)
+    protected function doProcess(string $tableName)
     {
         $flexFormDs = [
             'default' => '',

--- a/Classes/Core/Notification/TCA/Processor/GracefulProcessor.php
+++ b/Classes/Core/Notification/TCA/Processor/GracefulProcessor.php
@@ -19,7 +19,6 @@ namespace CuyZ\Notiz\Core\Notification\TCA\Processor;
 use CuyZ\Notiz\Core\Definition\DefinitionService;
 use CuyZ\Notiz\Service\Container;
 use CuyZ\Notiz\Service\ViewService;
-use Exception;
 use Throwable;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ArrayUtility;
@@ -75,11 +74,6 @@ abstract class GracefulProcessor implements SingletonInterface
         try {
             $this->doProcess($tableName);
         } catch (Throwable $exception) {
-        } catch (Exception $exception) {
-            // @PHP7
-        }
-
-        if ($exception) {
             if (GeneralUtility::_GET('showException')) {
                 throw $exception;
             }

--- a/Classes/Core/Notification/TCA/Processor/GracefulProcessor.php
+++ b/Classes/Core/Notification/TCA/Processor/GracefulProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -63,7 +64,7 @@ abstract class GracefulProcessor implements SingletonInterface
      * @param string $tableName
      * @throws Throwable
      */
-    final public function process($tableName)
+    final public function process(string $tableName)
     {
         if ($this->definitionService->getValidationResult()->hasErrors()) {
             return;
@@ -88,13 +89,13 @@ abstract class GracefulProcessor implements SingletonInterface
     /**
      * @param string $tableName
      */
-    abstract protected function doProcess($tableName);
+    abstract protected function doProcess(string $tableName);
 
     /**
      * @param Throwable $exception
      * @return array
      */
-    private function getDefinitionErrorTca($exception)
+    private function getDefinitionErrorTca(Throwable $exception): array
     {
         return [
             'types' => [
@@ -120,7 +121,7 @@ abstract class GracefulProcessor implements SingletonInterface
      * @param array $arguments
      * @return string
      */
-    public function getErrorMessage($arguments)
+    public function getErrorMessage($arguments): string
     {
         $view = $this->viewService->getStandaloneView('Backend/TCA/ErrorMessage');
 

--- a/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
+++ b/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
+++ b/Classes/Core/Notification/TCA/Processor/GracefulProcessorRunner.php
@@ -32,12 +32,9 @@ class GracefulProcessorRunner implements SingletonInterface, TableConfigurationP
     public function processData()
     {
         foreach ($GLOBALS['TCA'] as $tableName => $configuration) {
-            // @PHP7
-            if (!isset($configuration['ctrl'][EntityTcaWriter::NOTIFICATION_ENTITY]['processor'])) {
-                continue;
-            }
+            $processors = $configuration['ctrl'][EntityTcaWriter::NOTIFICATION_ENTITY]['processor'] ?? [];
 
-            foreach ($configuration['ctrl'][EntityTcaWriter::NOTIFICATION_ENTITY]['processor'] as $processorClassName) {
+            foreach ($processors as $processorClassName) {
                 /** @var GracefulProcessor $processor */
                 $processor = GeneralUtility::makeInstance($processorClassName);
 

--- a/Classes/Core/Notification/TCA/User/MissingCkEditorPreset.php
+++ b/Classes/Core/Notification/TCA/User/MissingCkEditorPreset.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -29,7 +30,7 @@ class MissingCkEditorPreset implements SingletonInterface
      * @param array $parent
      * @return string
      */
-    public function process(array $parent)
+    public function process(array $parent): string
     {
         $preset = $parent['parameters']['preset'];
 

--- a/Classes/Core/Notification/Viewable.php
+++ b/Classes/Core/Notification/Viewable.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -25,15 +26,15 @@ interface Viewable
     /**
      * @return bool
      */
-    public static function isListable();
+    public static function isListable(): bool;
 
     /**
      * @return bool
      */
-    public function isViewable();
+    public function isViewable(): bool;
 
     /**
      * @return string
      */
-    public function getViewUri();
+    public function getViewUri(): string;
 }

--- a/Classes/Core/Property/Builder/PropertyBuilder.php
+++ b/Classes/Core/Property/Builder/PropertyBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Property/Factory/PropertyContainer.php
+++ b/Classes/Core/Property/Factory/PropertyContainer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -72,7 +73,7 @@ class PropertyContainer
     /**
      * @return string
      */
-    public function getPropertyType()
+    public function getPropertyType(): string
     {
         return $this->definition->getPropertyType();
     }
@@ -81,7 +82,7 @@ class PropertyContainer
      * @param string $name
      * @return bool
      */
-    public function hasEntry($name)
+    public function hasEntry(string $name): bool
     {
         return isset($this->properties[$name]);
     }
@@ -92,7 +93,7 @@ class PropertyContainer
      *
      * @throws EntryNotFoundException
      */
-    public function getEntry($name)
+    public function getEntry(string $name): PropertyEntry
     {
         if (false === $this->hasEntry($name)) {
             throw EntryNotFoundException::propertyEntryNotFound($name, $this->definition->getEventClassName(), $this->getPropertyType(), $this);
@@ -104,7 +105,7 @@ class PropertyContainer
     /**
      * @return PropertyEntry[]
      */
-    public function getEntries()
+    public function getEntries(): array
     {
         return $this->properties;
     }

--- a/Classes/Core/Property/Factory/PropertyDefinition.php
+++ b/Classes/Core/Property/Factory/PropertyDefinition.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -72,7 +73,7 @@ class PropertyDefinition
      * @param string $eventClassName
      * @param string $propertyType
      */
-    public function __construct($eventClassName, $propertyType)
+    public function __construct(string $eventClassName, string $propertyType)
     {
         $this->eventClassName = $eventClassName;
         $this->propertyType = $propertyType;
@@ -81,7 +82,7 @@ class PropertyDefinition
     /**
      * @return string
      */
-    public function getEventClassName()
+    public function getEventClassName(): string
     {
         return $this->eventClassName;
     }
@@ -89,7 +90,7 @@ class PropertyDefinition
     /**
      * @return string
      */
-    public function getPropertyType()
+    public function getPropertyType(): string
     {
         return $this->propertyType;
     }
@@ -100,7 +101,7 @@ class PropertyDefinition
      *
      * @throws DuplicateEntryException
      */
-    public function addEntry($name)
+    public function addEntry(string $name): PropertyEntry
     {
         if ($this->hasEntry($name)) {
             throw DuplicateEntryException::propertyEntryDuplication($name, $this->eventClassName, $this->propertyType);
@@ -115,7 +116,7 @@ class PropertyDefinition
      * @param string $name
      * @return bool
      */
-    public function hasEntry($name)
+    public function hasEntry(string $name): bool
     {
         return isset($this->properties[$name]);
     }
@@ -126,7 +127,7 @@ class PropertyDefinition
      *
      * @throws EntryNotFoundException
      */
-    public function getEntry($name)
+    public function getEntry(string $name): PropertyEntry
     {
         if (false === $this->hasEntry($name)) {
             throw EntryNotFoundException::propertyEntryNotFound($name, $this->eventClassName, $this->propertyType, $this);
@@ -138,7 +139,7 @@ class PropertyDefinition
     /**
      * @return PropertyEntry[]
      */
-    public function getEntries()
+    public function getEntries(): array
     {
         return $this->properties;
     }

--- a/Classes/Core/Property/Factory/PropertyFactory.php
+++ b/Classes/Core/Property/Factory/PropertyFactory.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -143,7 +144,7 @@ class PropertyFactory implements SingletonInterface
      * @param Notification $notification
      * @return PropertyDefinition
      */
-    public function getPropertyDefinition($propertyClassName, EventDefinition $eventDefinition, Notification $notification)
+    public function getPropertyDefinition(string $propertyClassName, EventDefinition $eventDefinition, Notification $notification): PropertyDefinition
     {
         $propertyClassName = $this->objectContainer->getImplementationClassName($propertyClassName);
 
@@ -168,7 +169,7 @@ class PropertyFactory implements SingletonInterface
      * @param Event $event
      * @return PropertyContainer
      */
-    public function getPropertyContainer($propertyClassName, Event $event)
+    public function getPropertyContainer(string $propertyClassName, Event $event): PropertyContainer
     {
         $propertyClassName = $this->objectContainer->getImplementationClassName($propertyClassName);
 
@@ -187,7 +188,7 @@ class PropertyFactory implements SingletonInterface
      * @param Event $event
      * @return PropertyEntry[]
      */
-    public function getProperties($propertyClassName, Event $event)
+    public function getProperties(string $propertyClassName, Event $event): array
     {
         return $this->getPropertyContainer($propertyClassName, $event)->getEntries();
     }
@@ -198,7 +199,7 @@ class PropertyFactory implements SingletonInterface
      * @param Notification $notification
      * @return PropertyDefinition
      */
-    protected function buildPropertyDefinition($propertyClassName, EventDefinition $eventDefinition, Notification $notification)
+    protected function buildPropertyDefinition(string $propertyClassName, EventDefinition $eventDefinition, Notification $notification): PropertyDefinition
     {
         /** @var PropertyDefinition $propertyDefinition */
         $propertyDefinition = $this->objectManager->get(PropertyDefinition::class, $eventDefinition->getClassName(), $propertyClassName);
@@ -222,7 +223,7 @@ class PropertyFactory implements SingletonInterface
      * @param Event|HasProperties $event
      * @return PropertyContainer
      */
-    protected function buildPropertyContainer($propertyClassName, Event $event)
+    protected function buildPropertyContainer(string $propertyClassName, Event $event): PropertyContainer
     {
         $propertyDefinition = $this->getPropertyDefinition($propertyClassName, $event->getDefinition(), $event->getNotification());
 
@@ -288,7 +289,7 @@ class PropertyFactory implements SingletonInterface
      * @param EventDefinition $eventDefinition
      * @return bool
      */
-    protected function eventHasProperties(EventDefinition $eventDefinition)
+    protected function eventHasProperties(EventDefinition $eventDefinition): bool
     {
         return in_array(HasProperties::class, class_implements($eventDefinition->getClassName()));
     }

--- a/Classes/Core/Property/PropertyEntry.php
+++ b/Classes/Core/Property/PropertyEntry.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -59,7 +60,7 @@ abstract class PropertyEntry
     /**
      * @param string $name
      */
-    public function __construct($name)
+    public function __construct(string $name)
     {
         $this->name = $name;
     }
@@ -67,7 +68,7 @@ abstract class PropertyEntry
     /**
      * @return string
      */
-    final public function getName()
+    final public function getName(): string
     {
         return $this->name;
     }
@@ -75,7 +76,7 @@ abstract class PropertyEntry
     /**
      * @return string
      */
-    final public function getValue()
+    final public function getValue(): string
     {
         return $this->value;
     }
@@ -100,7 +101,7 @@ abstract class PropertyEntry
     /**
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return LocalizationService::localize($this->label);
     }
@@ -109,7 +110,7 @@ abstract class PropertyEntry
      * @param string $label
      * @return $this
      */
-    public function setLabel($label)
+    public function setLabel(string $label)
     {
         $this->label = $label;
 
@@ -130,7 +131,7 @@ abstract class PropertyEntry
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return (string)$this->getValue();
     }

--- a/Classes/Core/Property/Service/MarkerParser.php
+++ b/Classes/Core/Property/Service/MarkerParser.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -30,7 +31,7 @@ class MarkerParser implements SingletonInterface
      * @param Marker[] $markers
      * @return string
      */
-    public function replaceMarkers($string, array $markers)
+    public function replaceMarkers(string $string, array $markers): string
     {
         if (empty($markers)) {
             return $string;
@@ -64,7 +65,7 @@ class MarkerParser implements SingletonInterface
      * @param array $markers
      * @return array
      */
-    private function keyMarkersByName(array $markers)
+    private function keyMarkersByName(array $markers): array
     {
         $aux = [];
 
@@ -82,7 +83,7 @@ class MarkerParser implements SingletonInterface
      * @param $string
      * @return array
      */
-    private function matchMarkers($string)
+    private function matchMarkers($string): array
     {
         preg_match_all(
             '/{
@@ -104,7 +105,7 @@ class MarkerParser implements SingletonInterface
      * @param Marker $marker
      * @return mixed
      */
-    protected function getVariableValue($variable, $root, Marker $marker)
+    protected function getVariableValue(string $variable, string $root, Marker $marker)
     {
         // We need to have the root name to allow the ObjectAccess class to
         // retrieve the value.

--- a/Classes/Core/Property/Service/TagsPropertyService.php
+++ b/Classes/Core/Property/Service/TagsPropertyService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -171,7 +172,7 @@ class TagsPropertyService implements SingletonInterface
      * @throws InvalidClassException
      * @throws WrongFormatException
      */
-    public function setPropertyTagIdentifier($propertyType, $identifier)
+    public function setPropertyTagIdentifier(string $propertyType, string $identifier)
     {
         if (false === class_exists($propertyType)) {
             throw ClassNotFoundException::tagServicePropertyClassNotFound($propertyType, $identifier);
@@ -204,7 +205,7 @@ class TagsPropertyService implements SingletonInterface
      * @param PropertyReflection $property
      * @return string
      */
-    protected function getPropertyLabel(PropertyReflection $property)
+    protected function getPropertyLabel(PropertyReflection $property): string
     {
         return $property->isTaggedWith('label')
             ? reset($property->getTagValues('label'))
@@ -215,7 +216,7 @@ class TagsPropertyService implements SingletonInterface
      * @param PropertyDefinition $definition
      * @return string
      */
-    protected function getPropertyTagIdentifier(PropertyDefinition $definition)
+    protected function getPropertyTagIdentifier(PropertyDefinition $definition): string
     {
         $type = $definition->getPropertyType();
 
@@ -228,7 +229,7 @@ class TagsPropertyService implements SingletonInterface
      * @param string $identifier
      * @return string
      */
-    private function getFormattedIdentifier($identifier)
+    private function getFormattedIdentifier(string $identifier): string
     {
         // Converting case: `fooBar` will become `foo_bar`.
         $identifier = GeneralUtility::camelCaseToLowerCaseUnderscored($identifier);
@@ -244,7 +245,7 @@ class TagsPropertyService implements SingletonInterface
      * @param string $className
      * @return string
      */
-    private function getClassShortName($className)
+    private function getClassShortName(string $className): string
     {
         // Getting the last backslash of the class name.
         $className = strrchr($className, '\\');

--- a/Classes/Core/Support/NotizConstants.php
+++ b/Classes/Core/Support/NotizConstants.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Core/Support/Url.php
+++ b/Classes/Core/Support/Url.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -32,7 +33,7 @@ class Url
     /**
      * @return string
      */
-    public static function documentation()
+    public static function documentation(): string
     {
         return self::build(self::DOCUMENTATION_ROOT);
     }
@@ -40,7 +41,7 @@ class Url
     /**
      * @return string
      */
-    public static function documentationCreateCustomEvent()
+    public static function documentationCreateCustomEvent(): string
     {
         return self::build(self::DOCUMENTATION_CREATE_CUSTOM_EVENT);
     }
@@ -48,7 +49,7 @@ class Url
     /**
      * @return string
      */
-    public static function documentationTypoScriptDefinition()
+    public static function documentationTypoScriptDefinition(): string
     {
         return self::build(self::DOCUMENTATION_ADD_TYPOSCRIPT_DEFINITION);
     }
@@ -56,7 +57,7 @@ class Url
     /**
      * @return string
      */
-    public static function repository()
+    public static function repository(): string
     {
         return self::REPOSITORY;
     }
@@ -64,7 +65,7 @@ class Url
     /**
      * @return string
      */
-    public static function newIssue()
+    public static function newIssue(): string
     {
         return self::NEW_ISSUE;
     }
@@ -72,7 +73,7 @@ class Url
     /**
      * @return string
      */
-    public static function slackChannel()
+    public static function slackChannel(): string
     {
         return self::SLACK_CHANNEL;
     }
@@ -81,7 +82,7 @@ class Url
      * @param string $url
      * @return string
      */
-    private static function build($url)
+    private static function build(string $url): string
     {
         return vsprintf(
             $url,

--- a/Classes/Domain/Channel/Email/TYPO3/EmailChannel.php
+++ b/Classes/Domain/Channel/Email/TYPO3/EmailChannel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Channel/Log/LogChannel.php
+++ b/Classes/Domain/Channel/Log/LogChannel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -66,7 +67,7 @@ abstract class LogChannel extends AbstractChannel
      *
      * @return LoggerInterface
      */
-    abstract protected function getLoggerInstance();
+    abstract protected function getLoggerInstance(): LoggerInterface;
 
     /**
      * The logging itself is done here using the provided logger.

--- a/Classes/Domain/Channel/Log/Typo3LogChannel.php
+++ b/Classes/Domain/Channel/Log/Typo3LogChannel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -26,7 +27,7 @@ class Typo3LogChannel extends LogChannel
     /**
      * @return LoggerInterface
      */
-    protected function getLoggerInstance()
+    protected function getLoggerInstance(): LoggerInterface
     {
         /** @var Logger $logger */
         $logger = GeneralUtility::makeInstance(LogManager::class)

--- a/Classes/Domain/Channel/Slack/Typo3SlackChannel.php
+++ b/Classes/Domain/Channel/Slack/Typo3SlackChannel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -106,7 +107,7 @@ class Typo3SlackChannel extends AbstractChannel
      * @param string $webhookUrl
      * @param array $data
      */
-    protected function callSlack($webhookUrl, array $data)
+    protected function callSlack(string $webhookUrl, array $data)
     {
         /** @var RequestFactory $factory */
         $factory = GeneralUtility::makeInstance(RequestFactory::class);

--- a/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
+++ b/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -75,7 +76,7 @@ class DefaultDefinitionComponents implements SingletonInterface
     /**
      * @return array
      */
-    private function getDefaultFiles()
+    private function getDefaultFiles(): array
     {
         $defaultFiles = [
             NotizConstants::TYPOSCRIPT_PATH . 'Channel/Channels.Default.typoscript',

--- a/Classes/Domain/Definition/Builder/Component/Source/FileDefinitionSource.php
+++ b/Classes/Domain/Definition/Builder/Component/Source/FileDefinitionSource.php
@@ -103,10 +103,7 @@ abstract class FileDefinitionSource implements DefinitionSource, SingletonInterf
      */
     private function includeConfiguredSources()
     {
-        // @PHP7
-        $configuredSources = isset($GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['NotiZ']['Definition']['Source'][static::class])
-            ? $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['NotiZ']['Definition']['Source'][static::class]
-            : [];
+        $configuredSources = $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['NotiZ']['Definition']['Source'][static::class] ?? [];
 
         foreach ($configuredSources as $configuredSource) {
             $this->addFilePath((string)$configuredSource);

--- a/Classes/Domain/Definition/Builder/Component/Source/FileDefinitionSource.php
+++ b/Classes/Domain/Definition/Builder/Component/Source/FileDefinitionSource.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -58,7 +59,7 @@ abstract class FileDefinitionSource implements DefinitionSource, SingletonInterf
      *
      * @throws FileNotFoundException
      */
-    public function addFilePath($path, $priority = 0)
+    public function addFilePath(string $path, int $priority = 0)
     {
         if (!isset($this->filePaths[$priority])) {
             $this->filePaths[$priority] = [];
@@ -83,7 +84,7 @@ abstract class FileDefinitionSource implements DefinitionSource, SingletonInterf
     /**
      * @return Generator
      */
-    final protected function filePaths()
+    final protected function filePaths(): Generator
     {
         foreach ($this->filePaths as $priority => $paths) {
             foreach ($paths as $path) {

--- a/Classes/Domain/Definition/Builder/Component/Source/TypoScriptDefinitionSource.php
+++ b/Classes/Domain/Definition/Builder/Component/Source/TypoScriptDefinitionSource.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -88,7 +89,7 @@ class TypoScriptDefinitionSource extends FileDefinitionSource
      *
      * @return array
      */
-    public function getDefinitionArray()
+    public function getDefinitionArray(): array
     {
         $content = '';
 

--- a/Classes/Domain/Event/Form/DispatchFormNotificationEvent.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationEvent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -113,7 +114,7 @@ class DispatchFormNotificationEvent extends AbstractEvent implements ProvidesExa
     /**
      * @return array
      */
-    public function getExampleProperties()
+    public function getExampleProperties(): array
     {
         return [
             'formValues' => [

--- a/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -110,7 +111,7 @@ class DispatchFormNotificationEventPropertyBuilder implements PropertyBuilder, S
      * @param string $identifier
      * @return FormDefinition
      */
-    protected function getFormDefinition($identifier)
+    protected function getFormDefinition(string $identifier): FormDefinition
     {
         $formDefinitionArray = $this->formPersistenceManager->load($identifier);
 

--- a/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationEventPropertyBuilder.php
@@ -81,10 +81,7 @@ class DispatchFormNotificationEventPropertyBuilder implements PropertyBuilder, S
 
         $eventConfiguration = $notification->getEventConfiguration();
 
-        // @PHP7
-        $identifier = isset($eventConfiguration['formDefinition'])
-            ? $eventConfiguration['formDefinition']
-            : null;
+        $identifier = $eventConfiguration['formDefinition'] ?? null;
 
         if (!$identifier) {
             return;

--- a/Classes/Domain/Event/Form/DispatchFormNotificationFinisher.php
+++ b/Classes/Domain/Event/Form/DispatchFormNotificationFinisher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Event/Form/Service/ListFormNotifications.php
+++ b/Classes/Domain/Event/Form/Service/ListFormNotifications.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Event/Form/Service/ListFormNotifications.php
+++ b/Classes/Domain/Event/Form/Service/ListFormNotifications.php
@@ -48,11 +48,7 @@ class ListFormNotifications implements SingletonInterface
         foreach ($this->formPersistenceManager->listForms() as $form) {
             $persistenceIdentifier = $form['persistenceIdentifier'];
             $formDefinition = $this->formPersistenceManager->load($persistenceIdentifier);
-
-            // @PHP7
-            $finishers = isset($formDefinition['finishers'])
-                ? $formDefinition['finishers']
-                : [];
+            $finishers = $formDefinition['finishers'] ?? [];
 
             foreach ($finishers as $finisher) {
                 if ($finisher['identifier'] === DispatchFormNotificationFinisher::DISPATCH_NOTIFICATION) {

--- a/Classes/Domain/Event/Scheduler/SchedulerTaskEvent.php
+++ b/Classes/Domain/Event/Scheduler/SchedulerTaskEvent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -84,7 +85,7 @@ abstract class SchedulerTaskEvent extends AbstractEvent implements ProvidesExamp
     /**
      * @return array
      */
-    public function getExampleProperties()
+    public function getExampleProperties(): array
     {
         return [
             'uid' => '42',

--- a/Classes/Domain/Event/Scheduler/SchedulerTaskExecutionFailedEvent.php
+++ b/Classes/Domain/Event/Scheduler/SchedulerTaskExecutionFailedEvent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -38,7 +39,7 @@ class SchedulerTaskExecutionFailedEvent extends SchedulerTaskEvent
      * @param AbstractTask $task
      * @param Throwable $exception
      */
-    public function run(AbstractTask $task, $exception)
+    public function run(AbstractTask $task, Throwable $exception)
     {
         $this->checkTaskFilter($task);
         $this->fillTaskData($task);
@@ -49,7 +50,7 @@ class SchedulerTaskExecutionFailedEvent extends SchedulerTaskEvent
     /**
      * @return array
      */
-    public function getExampleProperties()
+    public function getExampleProperties(): array
     {
         return parent::getExampleProperties() +
             [

--- a/Classes/Domain/Event/Scheduler/SchedulerTaskWasExecutedEvent.php
+++ b/Classes/Domain/Event/Scheduler/SchedulerTaskWasExecutedEvent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -35,7 +36,7 @@ class SchedulerTaskWasExecutedEvent extends SchedulerTaskEvent
      * @param AbstractTask $task
      * @param bool $result
      */
-    public function run(AbstractTask $task, $result)
+    public function run(AbstractTask $task, bool $result)
     {
         $this->checkTaskFilter($task);
         $this->fillTaskData($task);
@@ -46,7 +47,7 @@ class SchedulerTaskWasExecutedEvent extends SchedulerTaskEvent
     /**
      * @return array
      */
-    public function getExampleProperties()
+    public function getExampleProperties(): array
     {
         return parent::getExampleProperties() +
             [

--- a/Classes/Domain/Event/TYPO3/CachesClearedEvent.php
+++ b/Classes/Domain/Event/TYPO3/CachesClearedEvent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -61,7 +62,7 @@ class CachesClearedEvent extends AbstractEvent implements ProvidesExamplePropert
     /**
      * @return array
      */
-    public function getExampleProperties()
+    public function getExampleProperties(): array
     {
         return [
             'cacheCommand' => 'page',

--- a/Classes/Domain/Event/TYPO3/ExtensionInstalledEvent.php
+++ b/Classes/Domain/Event/TYPO3/ExtensionInstalledEvent.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -66,7 +67,7 @@ class ExtensionInstalledEvent extends AbstractEvent implements ProvidesExamplePr
     /**
      * @param string $extensionKey
      */
-    public function run($extensionKey)
+    public function run(string $extensionKey)
     {
         $extension = $this->getExtensionData($extensionKey);
 
@@ -80,7 +81,7 @@ class ExtensionInstalledEvent extends AbstractEvent implements ProvidesExamplePr
      * @param string $extensionKey
      * @return array
      */
-    protected function getExtensionData($extensionKey)
+    protected function getExtensionData(string $extensionKey): array
     {
         $extensionPackage = $this->listUtility->getExtension($extensionKey);
 
@@ -105,7 +106,7 @@ class ExtensionInstalledEvent extends AbstractEvent implements ProvidesExamplePr
     /**
      * @return array
      */
-    public function getExampleProperties()
+    public function getExampleProperties(): array
     {
         return [
             'key' => 'my_extension',

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/EntityEmailNotification.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/EntityEmailNotification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -101,7 +102,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getLayout()
+    public function getLayout(): string
     {
         return $this->layout;
     }
@@ -109,7 +110,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $layout
      */
-    public function setLayout($layout)
+    public function setLayout(string $layout)
     {
         $this->layout = $layout;
     }
@@ -117,7 +118,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getSender()
+    public function getSender(): string
     {
         return $this->sender;
     }
@@ -125,7 +126,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $sender
      */
-    public function setSender($sender)
+    public function setSender(string $sender)
     {
         $this->sender = $sender;
     }
@@ -133,7 +134,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return bool
      */
-    public function isSenderCustom()
+    public function isSenderCustom(): bool
     {
         return $this->senderCustom;
     }
@@ -141,7 +142,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param bool $senderCustom
      */
-    public function setSenderCustom($senderCustom)
+    public function setSenderCustom(bool $senderCustom)
     {
         $this->senderCustom = $senderCustom;
     }
@@ -149,7 +150,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getSendTo()
+    public function getSendTo(): string
     {
         return $this->sendTo;
     }
@@ -157,7 +158,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $sendTo
      */
-    public function setSendTo($sendTo)
+    public function setSendTo(string $sendTo)
     {
         $this->sendTo = $sendTo;
     }
@@ -165,7 +166,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getSendToProvided()
+    public function getSendToProvided(): string
     {
         return $this->sendToProvided;
     }
@@ -173,7 +174,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return Email[]
      */
-    public function getSelectedSendToProvided()
+    public function getSelectedSendToProvided(): array
     {
         return $this->getSelectedProvidedRecipients($this->sendToProvided);
     }
@@ -181,7 +182,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $sendToProvided
      */
-    public function setSendToProvided($sendToProvided)
+    public function setSendToProvided(string $sendToProvided)
     {
         $this->sendToProvided = $sendToProvided;
     }
@@ -189,7 +190,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getSendCc()
+    public function getSendCc(): string
     {
         return $this->sendCc;
     }
@@ -197,7 +198,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $sendCc
      */
-    public function setSendCc($sendCc)
+    public function setSendCc(string $sendCc)
     {
         $this->sendCc = $sendCc;
     }
@@ -205,7 +206,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getSendCcProvided()
+    public function getSendCcProvided(): string
     {
         return $this->sendCcProvided;
     }
@@ -213,7 +214,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return Email[]
      */
-    public function getSelectedSendCcProvided()
+    public function getSelectedSendCcProvided(): array
     {
         return $this->getSelectedProvidedRecipients($this->sendCcProvided);
     }
@@ -221,7 +222,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $sendCcProvided
      */
-    public function setSendCcProvided($sendCcProvided)
+    public function setSendCcProvided(string $sendCcProvided)
     {
         $this->sendCcProvided = $sendCcProvided;
     }
@@ -229,7 +230,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getSendBcc()
+    public function getSendBcc(): string
     {
         return $this->sendBcc;
     }
@@ -237,7 +238,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $sendBcc
      */
-    public function setSendBcc($sendBcc)
+    public function setSendBcc(string $sendBcc)
     {
         $this->sendBcc = $sendBcc;
     }
@@ -245,7 +246,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getSendBccProvided()
+    public function getSendBccProvided(): string
     {
         return $this->sendBccProvided;
     }
@@ -253,7 +254,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return Email[]
      */
-    public function getSelectedSendBccProvided()
+    public function getSelectedSendBccProvided(): array
     {
         return $this->getSelectedProvidedRecipients($this->sendBccProvided);
     }
@@ -261,7 +262,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $sendBccProvided
      */
-    public function setSendBccProvided($sendBccProvided)
+    public function setSendBccProvided(string $sendBccProvided)
     {
         $this->sendBccProvided = $sendBccProvided;
     }
@@ -269,7 +270,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getSubject()
+    public function getSubject(): string
     {
         return $this->subject;
     }
@@ -277,7 +278,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $subject
      */
-    public function setSubject($subject)
+    public function setSubject(string $subject)
     {
         $this->subject = $subject;
     }
@@ -285,7 +286,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getBody()
+    public function getBody(): string
     {
         return $this->body;
     }
@@ -293,7 +294,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return array
      */
-    public function getBodySlots()
+    public function getBodySlots(): array
     {
         if (empty($this->bodySlots)) {
             /** @var FlexFormService $flexFormService */
@@ -308,7 +309,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @param string $body
      */
-    public function setBody($body)
+    public function setBody(string $body)
     {
         $this->body = $body;
     }
@@ -316,7 +317,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public static function getProcessorClassName()
+    public static function getProcessorClassName(): string
     {
         return EntityEmailNotificationProcessor::class;
     }
@@ -324,7 +325,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public static function getDefinitionIdentifier()
+    public static function getDefinitionIdentifier(): string
     {
         return 'entityEmail';
     }
@@ -332,7 +333,7 @@ class EntityEmailNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public static function getSettingsClassName()
+    public static function getSettingsClassName(): string
     {
         return EntityEmailSettings::class;
     }
@@ -341,7 +342,7 @@ class EntityEmailNotification extends EntityNotification implements
      * @param string $providedRecipients
      * @return Email[]
      */
-    protected function getSelectedProvidedRecipients($providedRecipients)
+    protected function getSelectedProvidedRecipients(string $providedRecipients): array
     {
         if (!$this->hasEventDefinition()) {
             return [];

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Processor/EntityEmailNotificationProcessor.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Processor/EntityEmailNotificationProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Repository/EntityEmailNotificationRepository.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Repository/EntityEmailNotificationRepository.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailAddressMapper.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailAddressMapper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -64,7 +65,7 @@ class EntityEmailAddressMapper
      *
      * @return string
      */
-    public function getSender()
+    public function getSender(): string
     {
         return $this->notification->isSenderCustom()
             ? $this->notification->getSender()
@@ -77,7 +78,7 @@ class EntityEmailAddressMapper
      *
      * @return array
      */
-    public function getSendTo()
+    public function getSendTo(): array
     {
         return $this->getMergedRecipients(
             $this->notification->getSendTo(),
@@ -91,7 +92,7 @@ class EntityEmailAddressMapper
      *
      * @return array
      */
-    public function getSendCc()
+    public function getSendCc(): array
     {
         return $this->getMergedRecipients(
             $this->notification->getSendCc(),
@@ -105,7 +106,7 @@ class EntityEmailAddressMapper
      *
      * @return array
      */
-    public function getSendBcc()
+    public function getSendBcc(): array
     {
         return $this->getMergedRecipients(
             $this->notification->getSendBcc(),
@@ -120,7 +121,7 @@ class EntityEmailAddressMapper
      * @param string $provided
      * @return array
      */
-    protected function getMergedRecipients($manual, $provided)
+    protected function getMergedRecipients(string $manual, string $provided): array
     {
         $manual = $this->recipientStringToArray($manual);
         $provided = $this->recipientStringToArray($provided);
@@ -144,7 +145,7 @@ class EntityEmailAddressMapper
      * @param $recipients
      * @return array
      */
-    protected function recipientStringToArray($recipients)
+    protected function recipientStringToArray($recipients): array
     {
         $recipients = trim($recipients);
         $recipients = str_replace(',', ';', $recipients);
@@ -162,7 +163,7 @@ class EntityEmailAddressMapper
      * @param array $recipients
      * @return array
      */
-    protected function parseRecipientsStrings(array $recipients)
+    protected function parseRecipientsStrings(array $recipients): array
     {
         return array_map(
             [StringService::get(), 'formatEmailAddress'],
@@ -177,7 +178,7 @@ class EntityEmailAddressMapper
      * @param array $recipientsIdentifiers
      * @return array
      */
-    protected function mapRecipients(array $recipientsIdentifiers)
+    protected function mapRecipients(array $recipientsIdentifiers): array
     {
         $recipients = [];
 
@@ -211,7 +212,7 @@ class EntityEmailAddressMapper
      * @param array $recipients
      * @return array
      */
-    protected function prepareRecipientsForMailMessage(array $recipients)
+    protected function prepareRecipientsForMailMessage(array $recipients): array
     {
         $emails = [];
 
@@ -232,7 +233,7 @@ class EntityEmailAddressMapper
      * @param array $recipients
      * @return array
      */
-    protected function cleanupRecipients(array $recipients)
+    protected function cleanupRecipients(array $recipients): array
     {
         $uniqueRecipients = [];
 

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailTemplateBuilder.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Service/EntityEmailTemplateBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -79,7 +80,7 @@ class EntityEmailTemplateBuilder
     /**
      * @return string
      */
-    public function getSubject()
+    public function getSubject(): string
     {
         return $this->markerParser->replaceMarkers(
             $this->notification->getSubject(),
@@ -90,7 +91,7 @@ class EntityEmailTemplateBuilder
     /**
      * @return string
      */
-    public function getBody()
+    public function getBody(): string
     {
         $eventDefinition = $this->event->getDefinition();
         $viewSettings = $this->notificationSettings->getView();

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/EntityEmailSettings.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/EntityEmailSettings.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -44,7 +45,7 @@ class EntityEmailSettings extends AbstractDefinitionComponent implements Notific
     /**
      * @return string
      */
-    public function getDefaultSender()
+    public function getDefaultSender(): string
     {
         return $this->defaultSender;
     }
@@ -52,7 +53,7 @@ class EntityEmailSettings extends AbstractDefinitionComponent implements Notific
     /**
      * @return GlobalRecipients\GlobalRecipients
      */
-    public function getGlobalRecipients()
+    public function getGlobalRecipients(): GlobalRecipients\GlobalRecipients
     {
         return $this->globalRecipients;
     }
@@ -60,7 +61,7 @@ class EntityEmailSettings extends AbstractDefinitionComponent implements Notific
     /**
      * @return View
      */
-    public function getView()
+    public function getView(): View
     {
         return $this->view;
     }

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/GlobalRecipients/GlobalRecipients.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/GlobalRecipients/GlobalRecipients.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -30,7 +31,7 @@ class GlobalRecipients extends AbstractDefinitionComponent implements DataPrePro
     /**
      * @return Recipient[]
      */
-    public function getRecipients()
+    public function getRecipients(): array
     {
         return $this->recipients;
     }

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/GlobalRecipients/Recipient.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/GlobalRecipients/Recipient.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -49,7 +50,7 @@ class Recipient extends AbstractDefinitionComponent implements DataPreProcessorI
     /**
      * @return string
      */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->email;
     }
@@ -57,7 +58,7 @@ class Recipient extends AbstractDefinitionComponent implements DataPreProcessorI
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name ?: $this->email;
     }
@@ -65,7 +66,7 @@ class Recipient extends AbstractDefinitionComponent implements DataPreProcessorI
     /**
      * @return string
      */
-    public function getRawValue()
+    public function getRawValue(): string
     {
         return $this->rawValue;
     }
@@ -73,7 +74,7 @@ class Recipient extends AbstractDefinitionComponent implements DataPreProcessorI
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return self::IDENTIFIER_PREFIX . $this->getArrayIndex();
     }

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/View/Layout.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/View/Layout.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -44,7 +45,7 @@ class Layout extends AbstractDefinitionComponent
      * @param string $identifier
      * @param string $path
      */
-    public function __construct($identifier, $path)
+    public function __construct(string $identifier, string $path)
     {
         $this->identifier = $identifier;
         $this->path = $path;
@@ -53,7 +54,7 @@ class Layout extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->identifier;
     }
@@ -61,7 +62,7 @@ class Layout extends AbstractDefinitionComponent
     /**
      * @return bool
      */
-    public function hasLabel()
+    public function hasLabel(): bool
     {
         return strlen(trim($this->label)) > 0;
     }
@@ -69,7 +70,7 @@ class Layout extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return LocalizationService::localize($this->label);
     }
@@ -77,7 +78,7 @@ class Layout extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getPath()
+    public function getPath(): string
     {
         return $this->path;
     }

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/View/View.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/Settings/View/View.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -47,7 +48,7 @@ class View extends AbstractDefinitionComponent implements ViewPathsAware, DataPr
     /**
      * @return Layout[]
      */
-    public function getLayouts()
+    public function getLayouts(): array
     {
         return $this->layouts;
     }
@@ -56,7 +57,7 @@ class View extends AbstractDefinitionComponent implements ViewPathsAware, DataPr
      * @param string $identifier
      * @return bool
      */
-    public function hasLayout($identifier)
+    public function hasLayout(string $identifier): bool
     {
         return true === isset($this->layouts[$identifier]);
     }
@@ -67,7 +68,7 @@ class View extends AbstractDefinitionComponent implements ViewPathsAware, DataPr
      *
      * @throws EntryNotFoundException
      */
-    public function getLayout($identifier)
+    public function getLayout(string $identifier): Layout
     {
         if (false === $this->hasLayout($identifier)) {
             throw EntryNotFoundException::entityEmailViewLayoutNotFound($identifier);
@@ -79,7 +80,7 @@ class View extends AbstractDefinitionComponent implements ViewPathsAware, DataPr
     /**
      * @return array
      */
-    public function getLayoutRootPaths()
+    public function getLayoutRootPaths(): array
     {
         return $this->layoutRootPaths;
     }
@@ -87,7 +88,7 @@ class View extends AbstractDefinitionComponent implements ViewPathsAware, DataPr
     /**
      * @return array
      */
-    public function getTemplateRootPaths()
+    public function getTemplateRootPaths(): array
     {
         return $this->templateRootPaths;
     }
@@ -95,7 +96,7 @@ class View extends AbstractDefinitionComponent implements ViewPathsAware, DataPr
     /**
      * @return array
      */
-    public function getPartialRootPaths()
+    public function getPartialRootPaths(): array
     {
         return $this->partialRootPaths;
     }

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaService.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -109,7 +110,7 @@ class EntityEmailTcaService extends NotificationTcaService
     /**
      * @return string
      */
-    public function getDefaultSender()
+    public function getDefaultSender(): string
     {
         if ($this->definitionHasErrors()) {
             return '';
@@ -125,7 +126,7 @@ class EntityEmailTcaService extends NotificationTcaService
      * @param array $parameters
      * @return bool
      */
-    public function shouldShowProvidedRecipientsSelect(array $parameters)
+    public function shouldShowProvidedRecipientsSelect(array $parameters): bool
     {
         if ($this->definitionHasErrors()) {
             return false;
@@ -148,7 +149,7 @@ class EntityEmailTcaService extends NotificationTcaService
     /**
      * @return EntityEmailSettings|NotificationSettings
      */
-    protected function getNotificationSettings()
+    protected function getNotificationSettings(): EntityEmailSettings
     {
         return $this->getNotificationDefinition()->getSettings();
     }
@@ -156,7 +157,7 @@ class EntityEmailTcaService extends NotificationTcaService
     /**
      * @return string
      */
-    protected function getDefinitionIdentifier()
+    protected function getDefinitionIdentifier(): string
     {
         return EntityEmailNotification::getDefinitionIdentifier();
     }

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaWriter.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaWriter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -31,7 +32,7 @@ class EntityEmailTcaWriter extends EntityTcaWriter
     /**
      * @return string
      */
-    protected function getNotificationTcaServiceClass()
+    protected function getNotificationTcaServiceClass(): string
     {
         return EntityEmailTcaService::class;
     }
@@ -39,7 +40,7 @@ class EntityEmailTcaWriter extends EntityTcaWriter
     /**
      * @return string
      */
-    protected function getChannelLabel()
+    protected function getChannelLabel(): string
     {
         return self::EMAIL_LLL . ':field.mailer';
     }
@@ -47,7 +48,7 @@ class EntityEmailTcaWriter extends EntityTcaWriter
     /**
      * @inheritdoc
      */
-    protected function buildTcaArray()
+    protected function buildTcaArray(): array
     {
         return [
             'ctrl' => $this->getCtrl(),
@@ -256,7 +257,7 @@ class EntityEmailTcaWriter extends EntityTcaWriter
     /**
      * @return array
      */
-    protected function getCtrl()
+    protected function getCtrl(): array
     {
         $ctrl = $this->getDefaultCtrl();
 
@@ -271,7 +272,7 @@ class EntityEmailTcaWriter extends EntityTcaWriter
     /**
      * @return string
      */
-    protected function getEntityTitle()
+    protected function getEntityTitle(): string
     {
         return self::EMAIL_LLL . ':title';
     }

--- a/Classes/Domain/Notification/Email/EmailNotification.php
+++ b/Classes/Domain/Notification/Email/EmailNotification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -23,30 +24,30 @@ interface EmailNotification extends Notification
     /**
      * @return string
      */
-    public function getSender();
+    public function getSender(): string;
 
     /**
      * @return string
      */
-    public function getSendTo();
+    public function getSendTo(): string;
 
     /**
      * @return string
      */
-    public function getSendCc();
+    public function getSendCc(): string;
 
     /**
      * @return string
      */
-    public function getSendBcc();
+    public function getSendBcc(): string;
 
     /**
      * @return string
      */
-    public function getSubject();
+    public function getSubject(): string;
 
     /**
      * @return string
      */
-    public function getBody();
+    public function getBody(): string;
 }

--- a/Classes/Domain/Notification/EntityNotification.php
+++ b/Classes/Domain/Notification/EntityNotification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -88,7 +89,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @param string $title
      */
-    public function setTitle($title)
+    public function setTitle(string $title)
     {
         $this->title = $title;
     }
@@ -96,7 +97,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return string
      */
-    public function getDescription()
+    public function getDescription(): string
     {
         return $this->description;
     }
@@ -104,7 +105,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @param string $description
      */
-    public function setDescription($description)
+    public function setDescription(string $description)
     {
         $this->description = $description;
     }
@@ -112,7 +113,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return string
      */
-    public function getEvent()
+    public function getEvent(): string
     {
         return $this->event;
     }
@@ -120,7 +121,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @param string $event
      */
-    public function setEvent($event)
+    public function setEvent(string $event)
     {
         $this->event = $event;
     }
@@ -128,7 +129,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return string
      */
-    public function getChannel()
+    public function getChannel(): string
     {
         return $this->channel;
     }
@@ -136,7 +137,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @param string $channel
      */
-    public function setChannel($channel)
+    public function setChannel(string $channel)
     {
         $this->channel = $channel;
     }
@@ -144,7 +145,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @param string $eventConfigurationFlex
      */
-    public function setEventConfigurationFlex($eventConfigurationFlex)
+    public function setEventConfigurationFlex(string $eventConfigurationFlex)
     {
         $this->eventConfigurationFlex = $eventConfigurationFlex;
     }
@@ -152,7 +153,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return bool
      */
-    public function isActive()
+    public function isActive(): bool
     {
         return !$this->hidden;
     }
@@ -161,16 +162,16 @@ abstract class EntityNotification extends AbstractEntity implements Notification
      * @param bool $active
      * @return void
      */
-    public function setActive($active)
+    public function setActive(bool $active)
     {
         $this->hidden = !$active;
     }
 
     /**
-     * @param EventDefinition|null $eventDefinition
+     * @param EventDefinition|null $eventDefinition [PHP 7.1]
      * @return string
      */
-    public function getSwitchActivationUri(EventDefinition $eventDefinition = null)
+    public function getSwitchActivationUri(EventDefinition $eventDefinition = null): string
     {
         $arguments = [
             'notificationType' => $this->getNotificationDefinition()->getIdentifier(),
@@ -181,9 +182,10 @@ abstract class EntityNotification extends AbstractEntity implements Notification
             $arguments['filterEvent'] = $eventDefinition->getFullIdentifier();
         }
 
+        /** @var ManagerModuleHandler $managerModuleHandler */
         $managerModuleHandler = Container::get(ManagerModuleHandler::class);
 
-        return $managerModuleHandler
+        return (string)$managerModuleHandler
             ->getUriBuilder()
             ->forController('Backend\\Manager\\NotificationActivation')
             ->forAction('process')
@@ -194,7 +196,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return NotificationDefinition
      */
-    public function getNotificationDefinition()
+    public function getNotificationDefinition(): NotificationDefinition
     {
         return self::getDefinition()->getNotification(static::getDefinitionIdentifier());
     }
@@ -202,7 +204,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return bool
      */
-    public function hasEventDefinition()
+    public function hasEventDefinition(): bool
     {
         return self::getDefinition()->hasEventFromFullIdentifier($this->getEvent());
     }
@@ -210,7 +212,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return EventDefinition
      */
-    public function getEventDefinition()
+    public function getEventDefinition(): EventDefinition
     {
         return self::getDefinition()->getEventFromFullIdentifier($this->getEvent());
     }
@@ -220,7 +222,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
      *
      * @return array
      */
-    public function getEventConfiguration()
+    public function getEventConfiguration(): array
     {
         if (null === $this->eventConfiguration) {
             /** @var FlexFormService $flexFormService */
@@ -243,7 +245,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return bool
      */
-    public static function isCreatable()
+    public static function isCreatable(): bool
     {
         return Container::getBackendUser()
             && Container::getBackendUser()->check('tables_modify', self::getTableName());
@@ -253,7 +255,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
      * @param string $selectedEvent
      * @return string
      */
-    public static function getCreationUri($selectedEvent = null)
+    public static function getCreationUri(string $selectedEvent = null): string
     {
         $tableName = static::getTableName();
 
@@ -275,7 +277,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return bool
      */
-    public function isEditable()
+    public function isEditable(): bool
     {
         $backendUser = Container::getBackendUser();
 
@@ -299,7 +301,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return string
      */
-    public function getEditionUri()
+    public function getEditionUri(): string
     {
         $identifier = $this->getNotificationDefinition()->getIdentifier();
         $tableName = static::getTableName();
@@ -317,7 +319,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return bool
      */
-    public static function isListable()
+    public static function isListable(): bool
     {
         return Container::getBackendUser()
             && Container::getBackendUser()->check('tables_select', self::getTableName());
@@ -326,7 +328,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return bool
      */
-    public function isViewable()
+    public function isViewable(): bool
     {
         return self::isListable();
     }
@@ -334,15 +336,16 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return string
      */
-    public function getViewUri()
+    public function getViewUri(): string
     {
         $notificationDefinition = $this->getNotificationDefinition();
 
         $controller = 'Backend\\Manager\\Notification\\Show' . ucfirst($notificationDefinition->getIdentifier());
 
+        /** @var ManagerModuleHandler $managerModuleHandler */
         $managerModuleHandler = Container::get(ManagerModuleHandler::class);
 
-        return $managerModuleHandler
+        return (string)$managerModuleHandler
             ->getUriBuilder()
             ->forController($controller)
             ->forAction('show')
@@ -355,7 +358,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
      *
      * @inheritdoc
      */
-    public function shouldDispatch(ChannelDefinition $definition)
+    public function shouldDispatch(ChannelDefinition $definition): bool
     {
         return $definition->getClassName() === $this->getChannel();
     }
@@ -366,7 +369,7 @@ abstract class EntityNotification extends AbstractEntity implements Notification
      *
      * @return string
      */
-    public static function getTableName()
+    public static function getTableName(): string
     {
         /** @var ConfigurationManagerInterface $configurationManager */
         $configurationManager = Container::get(ConfigurationManagerInterface::class);
@@ -382,12 +385,12 @@ abstract class EntityNotification extends AbstractEntity implements Notification
     /**
      * @return string
      */
-    abstract public static function getDefinitionIdentifier();
+    abstract public static function getDefinitionIdentifier(): string;
 
     /**
      * @return Definition
      */
-    protected static function getDefinition()
+    protected static function getDefinition(): Definition
     {
         return DefinitionService::get()->getDefinition();
     }

--- a/Classes/Domain/Notification/Log/Application/EntityLog/EntityLogNotification.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/EntityLogNotification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -44,7 +45,7 @@ class EntityLogNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
@@ -52,7 +53,7 @@ class EntityLogNotification extends EntityNotification implements
     /**
      * @param string $message
      */
-    public function setMessage($message)
+    public function setMessage(string $message)
     {
         $this->message = $message;
     }
@@ -60,7 +61,7 @@ class EntityLogNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getLevel()
+    public function getLevel(): string
     {
         return $this->level;
     }
@@ -68,7 +69,7 @@ class EntityLogNotification extends EntityNotification implements
     /**
      * @param string $level
      */
-    public function setLevel($level)
+    public function setLevel(string $level)
     {
         $this->level = $level;
     }
@@ -76,7 +77,7 @@ class EntityLogNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public static function getProcessorClassName()
+    public static function getProcessorClassName(): string
     {
         return EntityLogNotificationProcessor::class;
     }
@@ -84,7 +85,7 @@ class EntityLogNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public static function getDefinitionIdentifier()
+    public static function getDefinitionIdentifier(): string
     {
         return 'entityLog';
     }

--- a/Classes/Domain/Notification/Log/Application/EntityLog/Processor/EntityLogNotificationProcessor.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/Processor/EntityLogNotificationProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Notification/Log/Application/EntityLog/Repository/EntityLogNotificationRepository.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/Repository/EntityLogNotificationRepository.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Notification/Log/Application/EntityLog/Service/EntityLogMessageBuilder.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/Service/EntityLogMessageBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -55,7 +56,7 @@ class EntityLogMessageBuilder
     /**
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->markerParser->replaceMarkers(
             $this->notification->getMessage(),

--- a/Classes/Domain/Notification/Log/Application/EntityLog/TCA/EntityLogTcaService.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/TCA/EntityLogTcaService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -43,7 +44,7 @@ class EntityLogTcaService extends NotificationTcaService
     /**
      * @return string
      */
-    public function getLogLevelsDescriptions()
+    public function getLogLevelsDescriptions(): string
     {
         $lll = 'Notification/Log';
 
@@ -77,7 +78,7 @@ HTML;
     /**
      * @return array
      */
-    private function getLevels()
+    private function getLevels(): array
     {
         return [
             LogLevel::DEBUG,
@@ -94,7 +95,7 @@ HTML;
     /**
      * @return string
      */
-    protected function getDefinitionIdentifier()
+    protected function getDefinitionIdentifier(): string
     {
         return EntityLogNotification::getDefinitionIdentifier();
     }

--- a/Classes/Domain/Notification/Log/Application/EntityLog/TCA/EntityLogTcaWriter.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/TCA/EntityLogTcaWriter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -25,7 +26,7 @@ class EntityLogTcaWriter extends EntityTcaWriter
     /**
      * @return string
      */
-    protected function getNotificationTcaServiceClass()
+    protected function getNotificationTcaServiceClass(): string
     {
         return EntityLogTcaService::class;
     }
@@ -33,7 +34,7 @@ class EntityLogTcaWriter extends EntityTcaWriter
     /**
      * @return string
      */
-    protected function getChannelLabel()
+    protected function getChannelLabel(): string
     {
         return self::LOG_LLL . ':field.logger';
     }
@@ -41,7 +42,7 @@ class EntityLogTcaWriter extends EntityTcaWriter
     /**
      * @inheritdoc
      */
-    protected function buildTcaArray()
+    protected function buildTcaArray(): array
     {
         return [
             'ctrl' => $this->getDefaultCtrl(),
@@ -113,7 +114,7 @@ class EntityLogTcaWriter extends EntityTcaWriter
     /**
      * @return string
      */
-    protected function getEntityTitle()
+    protected function getEntityTitle(): string
     {
         return self::LOG_LLL . ':title';
     }

--- a/Classes/Domain/Notification/Log/LogNotification.php
+++ b/Classes/Domain/Notification/Log/LogNotification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -24,10 +25,10 @@ interface LogNotification extends Notification, MultipleChannelsNotification
     /**
      * @return string
      */
-    public function getLevel();
+    public function getLevel(): string;
 
     /**
      * @return string
      */
-    public function getMessage();
+    public function getMessage(): string;
 }

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Data/SlackBot.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Data/SlackBot.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -35,7 +36,7 @@ class SlackBot
      * @param string $name
      * @param string $avatar
      */
-    private function __construct($name, $avatar)
+    private function __construct(string $name, string $avatar)
     {
         $this->name = $name;
         $this->avatar = $avatar;
@@ -45,7 +46,7 @@ class SlackBot
      * @param SlackNotification $notification
      * @return static
      */
-    public static function fromNotification(SlackNotification $notification)
+    public static function fromNotification(SlackNotification $notification): self
     {
         return new static($notification->getName(), $notification->getAvatar());
     }
@@ -54,7 +55,7 @@ class SlackBot
      * @param Bot $bot
      * @return static
      */
-    public static function fromBotDefinition(Bot $bot)
+    public static function fromBotDefinition(Bot $bot): self
     {
         return new static($bot->getName(), $bot->getAvatar());
     }
@@ -62,7 +63,7 @@ class SlackBot
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -70,7 +71,7 @@ class SlackBot
     /**
      * @return string
      */
-    public function getAvatar()
+    public function getAvatar(): string
     {
         return $this->avatar;
     }
@@ -78,7 +79,7 @@ class SlackBot
     /**
      * @return bool
      */
-    public function hasEmojiAvatar()
+    public function hasEmojiAvatar(): bool
     {
         return substr($this->avatar, 0, 1) === ':'
             && substr($this->avatar, -1, 1) === ':';

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Data/SlackChannel.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Data/SlackChannel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -35,7 +36,7 @@ class SlackChannel
      * @param string $webhookUrl
      * @param string $target
      */
-    private function __construct($webhookUrl, $target)
+    private function __construct(string $webhookUrl, string $target)
     {
         $this->webhookUrl = $webhookUrl;
         $this->target = $target;
@@ -45,7 +46,7 @@ class SlackChannel
      * @param EntitySlackNotification $notification
      * @return static
      */
-    public static function fromNotification(EntitySlackNotification $notification)
+    public static function fromNotification(EntitySlackNotification $notification): self
     {
         return new static(
             $notification->getWebhookUrl(),
@@ -57,7 +58,7 @@ class SlackChannel
      * @param ChannelDefinition $channel
      * @return static
      */
-    public static function fromDefinition(ChannelDefinition $channel)
+    public static function fromDefinition(ChannelDefinition $channel): self
     {
         return new static($channel->getWebhookUrl(), $channel->getTarget());
     }
@@ -65,7 +66,7 @@ class SlackChannel
     /**
      * @return string
      */
-    public function getWebhookUrl()
+    public function getWebhookUrl(): string
     {
         return $this->webhookUrl;
     }
@@ -73,7 +74,7 @@ class SlackChannel
     /**
      * @return string
      */
-    public function getTarget()
+    public function getTarget(): string
     {
         return $this->target;
     }

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/EntitySlackNotification.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/EntitySlackNotification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -77,7 +78,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->message;
     }
@@ -85,7 +86,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @param string $message
      */
-    public function setMessage($message)
+    public function setMessage(string $message)
     {
         $this->message = $message;
     }
@@ -93,7 +94,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return bool
      */
-    public function hasCustomBot()
+    public function hasCustomBot(): bool
     {
         return $this->customBot;
     }
@@ -101,7 +102,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @param bool $customBot
      */
-    public function setCustomBot($customBot)
+    public function setCustomBot(bool $customBot)
     {
         $this->customBot = $customBot;
     }
@@ -109,7 +110,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getBot()
+    public function getBot(): string
     {
         return $this->bot;
     }
@@ -117,7 +118,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @param string $bot
      */
-    public function setBot($bot)
+    public function setBot(string $bot)
     {
         $this->bot = $bot;
     }
@@ -125,7 +126,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return bool
      */
-    public function hasCustomSlackChannel()
+    public function hasCustomSlackChannel(): bool
     {
         return !empty($this->target) || !empty($this->webhookUrl);
     }
@@ -133,7 +134,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getSlackChannel()
+    public function getSlackChannel(): string
     {
         return $this->slackChannel;
     }
@@ -141,7 +142,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @param string $slackChannel
      */
-    public function setSlackChannel($slackChannel)
+    public function setSlackChannel(string $slackChannel)
     {
         $this->slackChannel = $slackChannel;
     }
@@ -149,7 +150,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getWebhookUrl()
+    public function getWebhookUrl(): string
     {
         return $this->webhookUrl;
     }
@@ -157,7 +158,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @param string $webhookUrl
      */
-    public function setWebhookUrl($webhookUrl)
+    public function setWebhookUrl(string $webhookUrl)
     {
         $this->webhookUrl = $webhookUrl;
     }
@@ -165,7 +166,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getTarget()
+    public function getTarget(): string
     {
         return $this->target;
     }
@@ -173,7 +174,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @param string $target
      */
-    public function setTarget($target)
+    public function setTarget(string $target)
     {
         $this->target = $target;
     }
@@ -181,7 +182,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -189,7 +190,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @param string $name
      */
-    public function setName($name)
+    public function setName(string $name)
     {
         $this->name = $name;
     }
@@ -197,7 +198,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public function getAvatar()
+    public function getAvatar(): string
     {
         return $this->avatar;
     }
@@ -205,7 +206,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @param string $avatar
      */
-    public function setAvatar($avatar)
+    public function setAvatar(string $avatar)
     {
         $this->avatar = $avatar;
     }
@@ -213,7 +214,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public static function getProcessorClassName()
+    public static function getProcessorClassName(): string
     {
         return EntitySlackNotificationProcessor::class;
     }
@@ -221,7 +222,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public static function getSettingsClassName()
+    public static function getSettingsClassName(): string
     {
         return EntitySlackSettings::class;
     }
@@ -229,7 +230,7 @@ class EntitySlackNotification extends EntityNotification implements
     /**
      * @return string
      */
-    public static function getDefinitionIdentifier()
+    public static function getDefinitionIdentifier(): string
     {
         return 'entitySlack';
     }

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Processor/EntitySlackNotificationProcessor.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Processor/EntitySlackNotificationProcessor.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Repository/EntitySlackNotificationRepository.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Repository/EntitySlackNotificationRepository.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Service/EntitySlackBotMapper.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Service/EntitySlackBotMapper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -49,7 +50,7 @@ class EntitySlackBotMapper
      * @return SlackBot
      * @throws EntryNotFoundException
      */
-    public function getBot()
+    public function getBot(): SlackBot
     {
         if ($this->notification->hasCustomBot()) {
             return SlackBot::fromNotification($this->notification);

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Service/EntitySlackChannelMapper.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Service/EntitySlackChannelMapper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -48,7 +49,7 @@ class EntitySlackChannelMapper
      *
      * @return SlackChannel[]
      */
-    public function getChannels()
+    public function getChannels(): array
     {
         $channels = [];
 

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Service/EntitySlackMessageBuilder.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Service/EntitySlackMessageBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -57,7 +58,7 @@ class EntitySlackMessageBuilder
      *
      * @return string
      */
-    public function getMessage()
+    public function getMessage(): string
     {
         return $this->markerParser->replaceMarkers(
             $this->notification->getMessage(),

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Settings/Bots/Bot.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Settings/Bots/Bot.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -38,7 +39,7 @@ class Bot extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -46,7 +47,7 @@ class Bot extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getAvatar()
+    public function getAvatar(): string
     {
         return $this->avatar;
     }
@@ -54,7 +55,7 @@ class Bot extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return self::IDENTIFIER_PREFIX . $this->getArrayIndex();
     }

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Settings/Channels/Channel.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Settings/Channels/Channel.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -41,7 +42,7 @@ class Channel extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label;
     }
@@ -49,7 +50,7 @@ class Channel extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getWebhookUrl()
+    public function getWebhookUrl(): string
     {
         return $this->webhookUrl;
     }
@@ -57,7 +58,7 @@ class Channel extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getTarget()
+    public function getTarget(): string
     {
         return $this->target;
     }
@@ -65,7 +66,7 @@ class Channel extends AbstractDefinitionComponent
     /**
      * @return string
      */
-    public function getIdentifier()
+    public function getIdentifier(): string
     {
         return $this->getArrayIndex();
     }

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/Settings/EntitySlackSettings.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/Settings/EntitySlackSettings.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -37,7 +38,7 @@ class EntitySlackSettings extends AbstractDefinitionComponent implements Notific
     /**
      * @return Bots\Bot[]
      */
-    public function getBots()
+    public function getBots(): array
     {
         return $this->bots;
     }
@@ -45,7 +46,7 @@ class EntitySlackSettings extends AbstractDefinitionComponent implements Notific
     /**
      * @return Channels\Channel[]
      */
-    public function getChannels()
+    public function getChannels(): array
     {
         return $this->channels;
     }
@@ -54,7 +55,7 @@ class EntitySlackSettings extends AbstractDefinitionComponent implements Notific
      * @param string $identifier
      * @return bool
      */
-    public function hasChannel($identifier)
+    public function hasChannel(string $identifier): bool
     {
         return isset($this->channels[$identifier]);
     }
@@ -65,7 +66,7 @@ class EntitySlackSettings extends AbstractDefinitionComponent implements Notific
      *
      * @throws EntryNotFoundException
      */
-    public function getChannel($identifier)
+    public function getChannel(string $identifier): Channels\Channel
     {
         if (!$this->hasChannel($identifier)) {
             throw EntryNotFoundException::entitySlackChannelDefinitionNotFound($identifier);

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaService.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -66,7 +67,7 @@ class EntitySlackTcaService extends NotificationTcaService
     /**
      * @return bool
      */
-    public function hasDefinedBot()
+    public function hasDefinedBot(): bool
     {
         if ($this->definitionHasErrors()) {
             return false;
@@ -78,7 +79,7 @@ class EntitySlackTcaService extends NotificationTcaService
     /**
      * @return bool
      */
-    public function hasNoDefinedBot()
+    public function hasNoDefinedBot(): bool
     {
         return !$this->hasDefinedBot();
     }
@@ -86,7 +87,7 @@ class EntitySlackTcaService extends NotificationTcaService
     /**
      * @return string
      */
-    public function getNoDefinedBotText()
+    public function getNoDefinedBotText(): string
     {
         $view = $this->viewService->getStandaloneView('Backend/TCA/NoDefinedBotMessage');
 
@@ -96,7 +97,7 @@ class EntitySlackTcaService extends NotificationTcaService
     /**
      * @return bool
      */
-    public function hasDefinedSlackChannel()
+    public function hasDefinedSlackChannel(): bool
     {
         if ($this->definitionHasErrors()) {
             return false;
@@ -108,7 +109,7 @@ class EntitySlackTcaService extends NotificationTcaService
     /**
      * @return bool
      */
-    public function hasNoDefinedSlackChannel()
+    public function hasNoDefinedSlackChannel(): bool
     {
         return !$this->hasDefinedSlackChannel();
     }
@@ -116,7 +117,7 @@ class EntitySlackTcaService extends NotificationTcaService
     /**
      * @return string
      */
-    public function getNoDefinedSlackChannelText()
+    public function getNoDefinedSlackChannelText(): string
     {
         $view = $this->viewService->getStandaloneView('Backend/TCA/NoDefinedSlackChannel');
 
@@ -126,7 +127,7 @@ class EntitySlackTcaService extends NotificationTcaService
     /**
      * @return EntitySlackSettings|NotificationSettings
      */
-    protected function getNotificationSettings()
+    protected function getNotificationSettings(): EntitySlackSettings
     {
         return $this->getNotificationDefinition()->getSettings();
     }
@@ -134,7 +135,7 @@ class EntitySlackTcaService extends NotificationTcaService
     /**
      * @return string
      */
-    protected function getDefinitionIdentifier()
+    protected function getDefinitionIdentifier(): string
     {
         return EntitySlackNotification::getDefinitionIdentifier();
     }

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -25,7 +26,7 @@ class EntitySlackTcaWriter extends EntityTcaWriter
     /**
      * @return array
      */
-    protected function buildTcaArray()
+    protected function buildTcaArray(): array
     {
         return [
             'ctrl' => $this->getCtrl(),
@@ -203,7 +204,7 @@ class EntitySlackTcaWriter extends EntityTcaWriter
     /**
      * @return array
      */
-    protected function getCtrl()
+    protected function getCtrl(): array
     {
         $ctrl = $this->getDefaultCtrl();
 
@@ -215,7 +216,7 @@ class EntitySlackTcaWriter extends EntityTcaWriter
     /**
      * @return string
      */
-    protected function getNotificationTcaServiceClass()
+    protected function getNotificationTcaServiceClass(): string
     {
         return EntitySlackTcaService::class;
     }
@@ -223,7 +224,7 @@ class EntitySlackTcaWriter extends EntityTcaWriter
     /**
      * @return string
      */
-    protected function getEntityTitle()
+    protected function getEntityTitle(): string
     {
         return self::SLACK_LLL . ':title';
     }

--- a/Classes/Domain/Notification/Slack/SlackNotification.php
+++ b/Classes/Domain/Notification/Slack/SlackNotification.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -24,17 +25,17 @@ interface SlackNotification extends Notification, MultipleChannelsNotification
     /**
      * @return string
      */
-    public function getMessage();
+    public function getMessage(): string;
 
     /**
      * @return bool
      */
-    public function hasCustomBot();
+    public function hasCustomBot(): bool;
 
     /**
      * @return string
      */
-    public function getBot();
+    public function getBot(): string;
 
     /**
      * This method should return `true` if the notification has a custom
@@ -42,30 +43,30 @@ interface SlackNotification extends Notification, MultipleChannelsNotification
      *
      * @return bool
      */
-    public function hasCustomSlackChannel();
+    public function hasCustomSlackChannel(): bool;
 
     /**
      * @return string
      */
-    public function getSlackChannel();
+    public function getSlackChannel(): string;
 
     /**
      * @return string
      */
-    public function getTarget();
+    public function getTarget(): string;
 
     /**
      * @return string
      */
-    public function getWebhookUrl();
+    public function getWebhookUrl(): string;
 
     /**
      * @return string
      */
-    public function getName();
+    public function getName(): string;
 
     /**
      * @return string
      */
-    public function getAvatar();
+    public function getAvatar(): string;
 }

--- a/Classes/Domain/Property/Builder/TagsPropertyBuilder.php
+++ b/Classes/Domain/Property/Builder/TagsPropertyBuilder.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Property/Email.php
+++ b/Classes/Domain/Property/Email.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Domain/Property/Marker.php
+++ b/Classes/Domain/Property/Marker.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -33,7 +34,7 @@ class Marker extends PropertyEntry
      *
      * @return string
      */
-    public function getFormattedName()
+    public function getFormattedName(): string
     {
         return sprintf(
             NotizConstants::DEFAULT_MARKER_FORMAT,

--- a/Classes/Domain/Repository/EntityNotificationRepository.php
+++ b/Classes/Domain/Repository/EntityNotificationRepository.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -41,7 +42,7 @@ class EntityNotificationRepository extends Repository
     /**
      * @return QueryResultInterface
      */
-    public function findAllWithDisabled()
+    public function findAllWithDisabled(): QueryResultInterface
     {
         return $this->createQueryWithoutEnableStatement()->execute();
     }
@@ -50,7 +51,7 @@ class EntityNotificationRepository extends Repository
      * @param EventDefinition $eventDefinition
      * @return QueryResultInterface
      */
-    public function findFromEventDefinition(EventDefinition $eventDefinition)
+    public function findFromEventDefinition(EventDefinition $eventDefinition): QueryResultInterface
     {
         return $this->getQueryForEvent($eventDefinition)->execute();
     }
@@ -59,7 +60,7 @@ class EntityNotificationRepository extends Repository
      * @param EventDefinition $eventDefinition
      * @return QueryResultInterface
      */
-    public function findFromEventDefinitionWithDisabled(EventDefinition $eventDefinition)
+    public function findFromEventDefinitionWithDisabled(EventDefinition $eventDefinition): QueryResultInterface
     {
         return $this->getQueryForEvent($eventDefinition, true)->execute();
     }
@@ -68,7 +69,7 @@ class EntityNotificationRepository extends Repository
      * @param EventDefinition $eventDefinition
      * @return int
      */
-    public function countFromEventDefinition(EventDefinition $eventDefinition)
+    public function countFromEventDefinition(EventDefinition $eventDefinition): int
     {
         return $this->getQueryForEvent($eventDefinition)->count();
     }
@@ -77,9 +78,9 @@ class EntityNotificationRepository extends Repository
      * Returns the wanted notification even if it was disabled.
      *
      * @param mixed $identifier
-     * @return EntityNotification|object
+     * @return EntityNotification
      */
-    public function findByIdentifierForce($identifier)
+    public function findByIdentifierForce($identifier): EntityNotification
     {
         $query = $this->createQueryWithoutEnableStatement();
 
@@ -90,13 +91,14 @@ class EntityNotificationRepository extends Repository
             )
         );
 
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $query->execute()->getFirst();
     }
 
     /**
      * @return QueryInterface
      */
-    protected function createQueryWithoutEnableStatement()
+    protected function createQueryWithoutEnableStatement(): QueryInterface
     {
         $query = $this->createQuery();
         $query->getQuerySettings()
@@ -110,7 +112,7 @@ class EntityNotificationRepository extends Repository
      * @param bool $withDisabled
      * @return QueryInterface
      */
-    protected function getQueryForEvent(EventDefinition $eventDefinition, $withDisabled = false)
+    protected function getQueryForEvent(EventDefinition $eventDefinition, bool $withDisabled = false): QueryInterface
     {
         $query = $this->createQuery($withDisabled);
 
@@ -125,7 +127,7 @@ class EntityNotificationRepository extends Repository
      * @param bool $withDisabled
      * @return QueryInterface
      */
-    public function createQuery($withDisabled = false)
+    public function createQuery(bool $withDisabled = false): QueryInterface
     {
         if (true === $withDisabled) {
             return $this->createQueryWithoutEnableStatement();

--- a/Classes/Service/CacheService.php
+++ b/Classes/Service/CacheService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -65,7 +66,7 @@ class CacheService implements SingletonInterface
      * @param string $key
      * @return mixed
      */
-    public function get($key)
+    public function get(string $key)
     {
         return $this->getCacheInstance()->get($key);
     }
@@ -78,7 +79,7 @@ class CacheService implements SingletonInterface
      * @param array $tags
      * @return $this
      */
-    public function set($key, $data, array $tags = [])
+    public function set(string $key, $data, array $tags = [])
     {
         $this->getCacheInstance()->set($key, $data, $tags);
 
@@ -91,7 +92,7 @@ class CacheService implements SingletonInterface
      * @param string $key
      * @return bool
      */
-    public function has($key)
+    public function has(string $key): bool
     {
         return $this->getCacheInstance()->has($key);
     }
@@ -102,7 +103,7 @@ class CacheService implements SingletonInterface
      *
      * @return bool
      */
-    public function cacheIsRegistered()
+    public function cacheIsRegistered(): bool
     {
         return $this->cacheManager->hasCache(NotizConstants::CACHE_ID);
     }
@@ -116,7 +117,7 @@ class CacheService implements SingletonInterface
      *
      * @return FrontendInterface
      */
-    protected function getCacheInstance()
+    protected function getCacheInstance(): FrontendInterface
     {
         if (null === $this->cacheInstance) {
             $this->cacheInstance = $this->cacheManager->hasCache(NotizConstants::CACHE_ID)
@@ -136,7 +137,7 @@ class CacheService implements SingletonInterface
      *
      * @return VariableFrontend
      */
-    protected function getBackupCache()
+    protected function getBackupCache(): VariableFrontend
     {
         $logger = $this->logManager->getLogger(__CLASS__);
         $logger->warning(self::BACKUP_CACHE_WARNING_MESSAGE);

--- a/Classes/Service/Container.php
+++ b/Classes/Service/Container.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -51,7 +52,7 @@ class Container implements SingletonInterface
      * @param mixed ...$arguments
      * @return object
      */
-    public static function get($className, ...$arguments)
+    public static function get(string $className, ...$arguments)
     {
         return static::getInstance()->objectManager->get($className, ...$arguments);
     }
@@ -59,7 +60,7 @@ class Container implements SingletonInterface
     /**
      * @return BackendUserAuthentication
      */
-    public static function getBackendUser()
+    public static function getBackendUser(): BackendUserAuthentication
     {
         return $GLOBALS['BE_USER'];
     }
@@ -67,7 +68,7 @@ class Container implements SingletonInterface
     /**
      * @return PageRepository
      */
-    public static function getPageRepository()
+    public static function getPageRepository(): PageRepository
     {
         $instance = self::getInstance();
 

--- a/Classes/Service/Extension/LocalConfigurationService.php
+++ b/Classes/Service/Extension/LocalConfigurationService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Service/Extension/TablesConfigurationService.php
+++ b/Classes/Service/Extension/TablesConfigurationService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/Service/ExtensionConfigurationService.php
+++ b/Classes/Service/ExtensionConfigurationService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -46,7 +47,7 @@ class ExtensionConfigurationService implements SingletonInterface
      *
      * @throws EntryNotFoundException
      */
-    public function getConfiguration($key)
+    public function getConfiguration(string $key): array
     {
         if (!isset($this->configuration[$key])) {
             throw EntryNotFoundException::extensionConfigurationEntryNotFound($key);
@@ -59,7 +60,7 @@ class ExtensionConfigurationService implements SingletonInterface
      * @param string $key
      * @return mixed
      */
-    public function getConfigurationValue($key)
+    public function getConfigurationValue(string $key)
     {
         $configuration = $this->getConfiguration($key);
 

--- a/Classes/Service/Hook/EventDefinitionRegisterer.php
+++ b/Classes/Service/Hook/EventDefinitionRegisterer.php
@@ -20,7 +20,6 @@ use CuyZ\Notiz\Core\Event\Service\EventRegistry;
 use CuyZ\Notiz\Core\Support\NotizConstants;
 use CuyZ\Notiz\Service\CacheService;
 use CuyZ\Notiz\Service\RuntimeService;
-use Exception;
 use Throwable;
 use TYPO3\CMS\Core\Database\TableConfigurationPostProcessingHookInterface;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -62,9 +61,6 @@ class EventDefinitionRegisterer implements SingletonInterface, TableConfiguratio
         try {
             EventRegistry::get()->registerEvents();
         } catch (Throwable $exception) {
-            RuntimeService::get()->setException($exception);
-        } catch (Exception $exception) {
-            // @PHP7
             RuntimeService::get()->setException($exception);
         }
     }

--- a/Classes/Service/Hook/EventDefinitionRegisterer.php
+++ b/Classes/Service/Hook/EventDefinitionRegisterer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -78,7 +79,7 @@ class EventDefinitionRegisterer implements SingletonInterface, TableConfiguratio
      *
      * @return bool
      */
-    protected function clearingInstallToolCache()
+    protected function clearingInstallToolCache(): bool
     {
         return false === CacheService::getInstance()->cacheIsRegistered()
             && isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][NotizConstants::CACHE_ID]);

--- a/Classes/Service/IconService.php
+++ b/Classes/Service/IconService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -50,7 +51,7 @@ class IconService implements SingletonInterface
      * @param NotificationDefinition $notification
      * @return string
      */
-    public function registerNotificationIcon(NotificationDefinition $notification)
+    public function registerNotificationIcon(NotificationDefinition $notification): string
     {
         $iconIdentifier = 'tx-notiz-icon-notification-' . $notification->getIdentifier();
 

--- a/Classes/Service/LocalizationService.php
+++ b/Classes/Service/LocalizationService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -70,13 +71,15 @@ class LocalizationService implements SingletonInterface
     /**
      * Static proxy to the method `doLocalize()`.
      *
-     * @param string $key
+     * @param string|null $key [PHP 7.1]
      * @param array $arguments
      * @return string
      */
-    public static function localize($key, array $arguments = [])
+    public static function localize($key, array $arguments = []): string
     {
-        return self::get()->doLocalize($key, $arguments);
+        return $key
+            ? self::get()->doLocalize($key, $arguments)
+            : '';
     }
 
     /**
@@ -86,7 +89,7 @@ class LocalizationService implements SingletonInterface
      * @param array $arguments
      * @return string
      */
-    public function doLocalize($path, array $arguments = [])
+    public function doLocalize(string $path, array $arguments = []): string
     {
         if (false === strpos($path, ':')) {
             $possiblePaths = $this->getPossiblePaths('locallang', $path);
@@ -128,7 +131,7 @@ class LocalizationService implements SingletonInterface
      *
      * @param string $extensionKey
      */
-    public function addExtensionKey($extensionKey)
+    public function addExtensionKey(string $extensionKey)
     {
         if (!in_array($extensionKey, $this->extensionKeys)) {
             $this->extensionKeys[] = $extensionKey;
@@ -140,7 +143,7 @@ class LocalizationService implements SingletonInterface
      * @param string $key
      * @return array
      */
-    protected function getPossiblePaths($file, $key)
+    protected function getPossiblePaths(string $file, string $key): array
     {
         return array_map(
             function ($extensionKey) use ($file, $key) {
@@ -163,9 +166,9 @@ class LocalizationService implements SingletonInterface
      *
      * @param string $key
      * @param array $arguments
-     * @return string
+     * @return string|null [PHP 7.1]
      */
-    protected function localizeInternal($key, array $arguments)
+    protected function localizeInternal(string $key, array $arguments)
     {
         return LocalizationUtility::translate(
             $key,

--- a/Classes/Service/ObjectService.php
+++ b/Classes/Service/ObjectService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -27,7 +28,7 @@ class ObjectService implements SingletonInterface
      * @param string $instanceName
      * @return bool
      */
-    public static function classInstanceOf($className, $instanceName)
+    public static function classInstanceOf(string $className, string $instanceName): bool
     {
         if (interface_exists($instanceName)
             && in_array($instanceName, class_implements($className))

--- a/Classes/Service/RuntimeService.php
+++ b/Classes/Service/RuntimeService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -42,7 +43,7 @@ class RuntimeService implements SingletonInterface
     /**
      * @param Throwable $exception
      */
-    public function setException($exception)
+    public function setException(Throwable $exception)
     {
         $error = new Error('Runtime exception: ' . $exception->getMessage(), 1507489776);
         DefinitionService::get()->getValidationResult()->addError($error);
@@ -51,7 +52,7 @@ class RuntimeService implements SingletonInterface
     }
 
     /**
-     * @return Throwable
+     * @return Throwable|null [PHP 7.1]
      */
     public function getException()
     {

--- a/Classes/Service/Scheduler/Scheduler.php
+++ b/Classes/Service/Scheduler/Scheduler.php
@@ -16,7 +16,6 @@
 
 namespace CuyZ\Notiz\Service\Scheduler;
 
-use Exception;
 use CuyZ\Notiz\Service\Container;
 use Throwable;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
@@ -87,7 +86,6 @@ class Scheduler extends \TYPO3\CMS\Scheduler\Scheduler
      */
     public function executeTask(AbstractTask $task)
     {
-        $result = false;
         $exception = null;
 
         try {
@@ -98,12 +96,9 @@ class Scheduler extends \TYPO3\CMS\Scheduler\Scheduler
                 self::SIGNAL_TASK_EXECUTED,
                 [$task, $result]
             );
-        } catch (Throwable $exception) {
-        } catch (Exception $exception) {
-            // @PHP7
-        }
 
-        if ($exception) {
+            return $result;
+        } catch (Throwable $exception) {
             $this->dispatcher->dispatch(
                 __CLASS__,
                 self::SIGNAL_TASK_FAILED,
@@ -112,7 +107,5 @@ class Scheduler extends \TYPO3\CMS\Scheduler\Scheduler
 
             throw $exception;
         }
-
-        return $result;
     }
 }

--- a/Classes/Service/Scheduler/Scheduler.php
+++ b/Classes/Service/Scheduler/Scheduler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -84,7 +85,7 @@ class Scheduler extends \TYPO3\CMS\Scheduler\Scheduler
      *
      * @throws Throwable
      */
-    public function executeTask(AbstractTask $task)
+    public function executeTask(AbstractTask $task): bool
     {
         $exception = null;
 

--- a/Classes/Service/Scheduler/SchedulerService.php
+++ b/Classes/Service/Scheduler/SchedulerService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -47,7 +48,7 @@ class SchedulerService implements SingletonInterface
      *
      * @return array
      */
-    public function getTasksList()
+    public function getTasksList(): array
     {
         /** @var ConnectionPool $connectionPool */
         $connectionPool = GeneralUtility::makeInstance(ConnectionPool::class);

--- a/Classes/Service/StringService.php
+++ b/Classes/Service/StringService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -29,11 +30,11 @@ class StringService implements SingletonInterface
      *
      * @see \CuyZ\Notiz\Service\StringService::doMark
      *
-     * @param string $content
+     * @param mixed $content
      * @param string $replacement
      * @return string
      */
-    public static function mark($content, $replacement = '<samp class="bg-info">$1</samp>')
+    public static function mark($content, string $replacement = '<samp class="bg-info">$1</samp>'): string
     {
         return self::get()->doMark($content, $replacement);
     }
@@ -50,16 +51,16 @@ class StringService implements SingletonInterface
      *
      * > Look at <samp class="bg-info">foo</samp> lorem ipsum...
      *
-     * @param string $content
+     * @param mixed $content
      * @param string $replacement
      * @return string
      */
-    public function doMark($content, $replacement)
+    public function doMark($content, string $replacement): string
     {
         return preg_replace(
             '/`([^`]+)`/',
             $replacement,
-            $content
+            (string)$content
         );
     }
 
@@ -88,7 +89,7 @@ class StringService implements SingletonInterface
      * @param string $email
      * @return array
      */
-    public function formatEmailAddress($email)
+    public function formatEmailAddress(string $email): array
     {
         if (preg_match('#([^<]+) <([^>]+)>#', $email, $matches)) {
             return [
@@ -107,7 +108,7 @@ class StringService implements SingletonInterface
      * @param string $string
      * @return string
      */
-    public function upperCamelCase($string)
+    public function upperCamelCase(string $string): string
     {
         return GeneralUtility::underscoredToUpperCamelCase(GeneralUtility::camelCaseToLowerCaseUnderscored($string));
     }
@@ -118,7 +119,8 @@ class StringService implements SingletonInterface
      * @param $text
      * @return string
      */
-    public function wrapLines($text)
+
+    public function wrapLines($text): string
     {
         $pad = function ($line) {
             return "<p>$line</p>";

--- a/Classes/Service/Traits/ExtendedSelfInstantiateTrait.php
+++ b/Classes/Service/Traits/ExtendedSelfInstantiateTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -22,13 +23,14 @@ use TYPO3\CMS\Extbase\Object\ObjectManager;
 trait ExtendedSelfInstantiateTrait
 {
     /**
-     * @return self|object
+     * @return self
      */
-    public static function get()
+    public static function get(): self
     {
         /** @var ObjectManager $objectManager */
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);
 
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return $objectManager->get(static::class);
     }
 }

--- a/Classes/Service/Traits/SelfInstantiateTrait.php
+++ b/Classes/Service/Traits/SelfInstantiateTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -21,10 +22,11 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 trait SelfInstantiateTrait
 {
     /**
-     * @return static|object
+     * @return static
      */
-    public static function get()
+    public static function get(): self
     {
+        /** @noinspection PhpIncompatibleReturnTypeInspection */
         return GeneralUtility::makeInstance(static::class);
     }
 }

--- a/Classes/Service/ViewService.php
+++ b/Classes/Service/ViewService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -27,7 +28,7 @@ class ViewService implements SingletonInterface
      * @param string $templateName
      * @return StandaloneView
      */
-    public function getStandaloneView($templateName)
+    public function getStandaloneView(string $templateName): StandaloneView
     {
         /** @var StandaloneView $view */
         $view = GeneralUtility::makeInstance(StandaloneView::class);

--- a/Classes/Validation/Validator/DefinitionValidator.php
+++ b/Classes/Validation/Validator/DefinitionValidator.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -91,7 +92,7 @@ class DefinitionValidator extends AbstractValidator
      * @param int $code
      * @param array $arguments
      */
-    protected function addPropertyError($path, $message, $code, array $arguments = [])
+    protected function addPropertyError(string $path, string $message, int $code, array $arguments = [])
     {
         $error = new Error($message, $code, $arguments);
         $this->result->forProperty($path)->addError($error);

--- a/Classes/View/Slot/Application/InputSlot.php
+++ b/Classes/View/Slot/Application/InputSlot.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -21,7 +22,7 @@ class InputSlot extends Slot
     /**
      * @return string
      */
-    public function getFlexFormConfiguration()
+    public function getFlexFormConfiguration(): string
     {
         return <<<XML
     <type>input</type>

--- a/Classes/View/Slot/Application/Slot.php
+++ b/Classes/View/Slot/Application/Slot.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -36,7 +37,7 @@ abstract class Slot
      *
      * @throws WrongFormatException
      */
-    public function __construct($name, $label)
+    public function __construct(string $name, string $label)
     {
         if (!preg_match('/[a-z]+[a-z0-9-_]*/i', $name)) {
             throw WrongFormatException::slotNameWrongFormat($name);
@@ -49,7 +50,7 @@ abstract class Slot
     /**
      * @return string
      */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -57,7 +58,7 @@ abstract class Slot
     /**
      * @return string
      */
-    public function getLabel()
+    public function getLabel(): string
     {
         return $this->label ?: $this->name;
     }
@@ -65,12 +66,12 @@ abstract class Slot
     /**
      * @return string
      */
-    abstract public function getFlexFormConfiguration();
+    abstract public function getFlexFormConfiguration(): string;
 
     /**
      * @return string
      */
-    public function getFlexFormAdditionalConfiguration()
+    public function getFlexFormAdditionalConfiguration(): string
     {
         return '';
     }

--- a/Classes/View/Slot/Application/TextSlot.php
+++ b/Classes/View/Slot/Application/TextSlot.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -40,9 +41,9 @@ class TextSlot extends Slot
      * @param string $name
      * @param string $label
      * @param bool $rte
-     * @param string $rteMode
+     * @param string|null $rteMode [PHP 7.1]
      */
-    public function __construct($name, $label, $rte, $rteMode)
+    public function __construct(string $name, string $label, bool $rte, $rteMode)
     {
         parent::__construct($name, $label);
 
@@ -53,7 +54,7 @@ class TextSlot extends Slot
     /**
      * @return string
      */
-    public function getFlexFormConfiguration()
+    public function getFlexFormConfiguration(): string
     {
         $flexForm = '
             <type>text</type>
@@ -91,7 +92,7 @@ class TextSlot extends Slot
     /**
      * @return string
      */
-    public function getFlexFormAdditionalConfiguration()
+    public function getFlexFormAdditionalConfiguration(): string
     {
         $flexForm = '';
 
@@ -107,7 +108,7 @@ class TextSlot extends Slot
     /**
      * @return bool
      */
-    private function isUsingLegacyRte()
+    private function isUsingLegacyRte(): bool
     {
         return ExtensionManagementUtility::isLoaded('rtehtmlarea')
             && !ExtensionManagementUtility::isLoaded('rte_ckeditor');

--- a/Classes/View/Slot/Service/SlotFlexFormService.php
+++ b/Classes/View/Slot/Service/SlotFlexFormService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -53,7 +54,7 @@ class SlotFlexFormService implements SingletonInterface
      * @param ViewPathsAware $viewPaths
      * @return array
      */
-    public function getNotificationFlexFormList(ViewPathsAware $viewPaths)
+    public function getNotificationFlexFormList(ViewPathsAware $viewPaths): array
     {
         $flexFormList = ['default' => $this->getDefaultFlexForm()];
 
@@ -71,7 +72,7 @@ class SlotFlexFormService implements SingletonInterface
      * @param SlotView $view
      * @return string
      */
-    public function getSlotViewFlexForm(SlotView $view)
+    public function getSlotViewFlexForm(SlotView $view): string
     {
         $hash = $this->getViewCacheHash($view);
 
@@ -92,7 +93,7 @@ class SlotFlexFormService implements SingletonInterface
      * For each slot, a text field will be added to the FlexForm.
      *
      * @param SlotView $view
-     * @return string
+     * @return string|null [PHP 7.1]
      */
     protected function buildSlotViewFlexForm(SlotView $view)
     {
@@ -117,7 +118,7 @@ class SlotFlexFormService implements SingletonInterface
      * @param string $sheets
      * @return string
      */
-    protected function getBase($sheets)
+    protected function getBase(string $sheets): string
     {
         return <<<XML
 <T3DataStructure>
@@ -136,7 +137,7 @@ XML;
      * @param string $slots
      * @return string
      */
-    protected function getSheet($identifier, $slots)
+    protected function getSheet(string $identifier, string $slots): string
     {
         return <<<XML
 <$identifier>
@@ -157,7 +158,7 @@ XML;
      * @param Slot $slot
      * @return string
      */
-    protected function getSlot(Slot $slot)
+    protected function getSlot(Slot $slot): string
     {
         $label = htmlspecialchars($slot->getLabel());
 
@@ -178,7 +179,7 @@ XML;
     /**
      * @return string
      */
-    protected function getDefaultFlexForm()
+    protected function getDefaultFlexForm(): string
     {
         return <<<XML
 <T3DataStructure>
@@ -205,7 +206,7 @@ XML;
      * @param SlotView $view
      * @return string
      */
-    protected function getViewCacheHash(SlotView $view)
+    protected function getViewCacheHash(SlotView $view): string
     {
         return 'slots-' . sha1(serialize([
                 $view->getTemplatePathAndFilename(),

--- a/Classes/View/Slot/Service/SlotViewService.php
+++ b/Classes/View/Slot/Service/SlotViewService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -52,7 +53,7 @@ class SlotViewService implements SingletonInterface
      * @param ViewPathsAware $viewPaths
      * @return SlotView
      */
-    public function buildView(EventDefinition $eventDefinition, ViewPathsAware $viewPaths)
+    public function buildView(EventDefinition $eventDefinition, ViewPathsAware $viewPaths): SlotView
     {
         /** @var SlotView $view */
         $view = Container::get(SlotView::class, $eventDefinition);
@@ -76,7 +77,7 @@ class SlotViewService implements SingletonInterface
      * @param ViewPathsAware $viewPaths
      * @return Generator
      */
-    public function getEventsViews(ViewPathsAware $viewPaths)
+    public function getEventsViews(ViewPathsAware $viewPaths): Generator
     {
         if ($this->definitionService->getValidationResult()->hasErrors()) {
             return;
@@ -95,7 +96,7 @@ class SlotViewService implements SingletonInterface
      * @param ViewPathsAware $viewPaths
      * @return Generator
      */
-    public function getEventsWithSlots(ViewPathsAware $viewPaths)
+    public function getEventsWithSlots(ViewPathsAware $viewPaths): Generator
     {
         foreach ($this->getEventsViews($viewPaths) as $event => $view) {
             /** @var SlotView $view */
@@ -109,7 +110,7 @@ class SlotViewService implements SingletonInterface
      * @param ViewPathsAware $viewPaths
      * @return Generator|SlotView[]
      */
-    public function getEventsWithoutSlots(ViewPathsAware $viewPaths)
+    public function getEventsWithoutSlots(ViewPathsAware $viewPaths): Generator
     {
         foreach ($this->getEventsViews($viewPaths) as $event => $view) {
             /** @var SlotView $view */
@@ -130,7 +131,7 @@ class SlotViewService implements SingletonInterface
      * @param EventDefinition $eventDefinition
      * @return string
      */
-    protected function getEventTemplatePath(EventDefinition $eventDefinition)
+    protected function getEventTemplatePath(EventDefinition $eventDefinition): string
     {
         $groupPath = $this->stringService->upperCamelCase($eventDefinition->getGroup()->getIdentifier());
         $eventPath = $this->stringService->upperCamelCase($eventDefinition->getIdentifier());

--- a/Classes/View/Slot/SlotContainer.php
+++ b/Classes/View/Slot/SlotContainer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -44,7 +45,7 @@ class SlotContainer
      * @param string $name
      * @return bool
      */
-    public function has($name)
+    public function has(string $name): bool
     {
         return isset($this->slots[$name]);
     }
@@ -52,7 +53,7 @@ class SlotContainer
     /**
      * @return Slot[]
      */
-    public function getList()
+    public function getList(): array
     {
         return $this->slots;
     }

--- a/Classes/View/Slot/SlotView.php
+++ b/Classes/View/Slot/SlotView.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -54,7 +55,7 @@ class SlotView extends StandaloneView
      *
      * @return SlotContainer
      */
-    public function getSlots()
+    public function getSlots(): SlotContainer
     {
         if (!$this->slots) {
             $this->slots = GeneralUtility::makeInstance(SlotContainer::class);
@@ -79,7 +80,7 @@ class SlotView extends StandaloneView
      * @param array $markers
      * @return string
      */
-    public function renderWithSlots(array $slotsValues, array $markers)
+    public function renderWithSlots(array $slotsValues, array $markers): string
     {
         $viewHelperVariableContainer = $this->baseRenderingContext->getViewHelperVariableContainer();
 
@@ -93,7 +94,7 @@ class SlotView extends StandaloneView
     /**
      * @return EventDefinition
      */
-    public function getEventDefinition()
+    public function getEventDefinition(): EventDefinition
     {
         return $this->eventDefinition;
     }

--- a/Classes/View/ViewPathsAware.php
+++ b/Classes/View/ViewPathsAware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -21,15 +22,15 @@ interface ViewPathsAware
     /**
      * @return array
      */
-    public function getLayoutRootPaths();
+    public function getLayoutRootPaths(): array;
 
     /**
      * @return array
      */
-    public function getTemplateRootPaths();
+    public function getTemplateRootPaths(): array;
 
     /**
      * @return array
      */
-    public function getPartialRootPaths();
+    public function getPartialRootPaths(): array;
 }

--- a/Classes/ViewHelpers/Backend/Module/HasAccessViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Module/HasAccessViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/Backend/Module/HasAccessViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Module/HasAccessViewHelper.php
@@ -41,6 +41,6 @@ class HasAccessViewHelper extends AbstractViewHelper
      */
     public function render()
     {
-        return ModuleHandler::forModule($this->arguments['module'])->canBeAccessed();
+        return ModuleHandler::for($this->arguments['module'])->canBeAccessed();
     }
 }

--- a/Classes/ViewHelpers/Backend/Module/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Module/LinkViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/Backend/Module/LinkViewHelper.php
+++ b/Classes/ViewHelpers/Backend/Module/LinkViewHelper.php
@@ -80,7 +80,7 @@ class LinkViewHelper extends AbstractTagBasedViewHelper
     {
         $content = $this->renderChildren();
 
-        $moduleHandler = ModuleHandler::forModule($this->arguments['module']);
+        $moduleHandler = ModuleHandler::for($this->arguments['module']);
 
         if (!$moduleHandler->canBeAccessed()) {
             return $content;

--- a/Classes/ViewHelpers/Format/WrapLinesViewHelper.php
+++ b/Classes/ViewHelpers/Format/WrapLinesViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
+++ b/Classes/ViewHelpers/Iterator/ChunkViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/MarkViewHelper.php
+++ b/Classes/ViewHelpers/MarkViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/Notification/HasEventViewHelper.php
+++ b/Classes/ViewHelpers/Notification/HasEventViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/Notification/Link/ActivateViewHelper.php
+++ b/Classes/ViewHelpers/Notification/Link/ActivateViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/Notification/Link/CreateViewHelper.php
+++ b/Classes/ViewHelpers/Notification/Link/CreateViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/Notification/Link/EditViewHelper.php
+++ b/Classes/ViewHelpers/Notification/Link/EditViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/Notification/Link/ShowViewHelper.php
+++ b/Classes/ViewHelpers/Notification/Link/ShowViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018

--- a/Classes/ViewHelpers/Slot/InputViewHelper.php
+++ b/Classes/ViewHelpers/Slot/InputViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -24,7 +25,7 @@ class InputViewHelper extends SlotViewHelper
     /**
      * @return Slot
      */
-    protected function getSlot()
+    protected function getSlot(): Slot
     {
         return new InputSlot(
             $this->getSlotName(),

--- a/Classes/ViewHelpers/Slot/RenderViewHelper.php
+++ b/Classes/ViewHelpers/Slot/RenderViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -160,7 +161,7 @@ class RenderViewHelper extends AbstractConditionViewHelper
      *
      * @throws DuplicateEntryException
      */
-    public static function getSlotValue(array $arguments, RenderingContextInterface $renderingContext)
+    public static function getSlotValue(array $arguments, RenderingContextInterface $renderingContext): string
     {
         self::$currentVariableContainer = $renderingContext->getViewHelperVariableContainer();
 
@@ -200,7 +201,7 @@ class RenderViewHelper extends AbstractConditionViewHelper
      * @param array $arguments
      * @return bool
      */
-    protected static function evaluateCondition($arguments = null)
+    protected static function evaluateCondition($arguments = null): bool
     {
         return self::getSlotContainer()->has($arguments['name']);
     }
@@ -208,7 +209,7 @@ class RenderViewHelper extends AbstractConditionViewHelper
     /**
      * @return SlotContainer
      */
-    protected static function getSlotContainer()
+    protected static function getSlotContainer(): SlotContainer
     {
         return self::$currentVariableContainer->get(SlotView::class, SlotView::SLOT_CONTAINER);
     }
@@ -216,7 +217,7 @@ class RenderViewHelper extends AbstractConditionViewHelper
     /**
      * @return array
      */
-    protected static function getSlotValues()
+    protected static function getSlotValues(): array
     {
         return self::$currentVariableContainer->get(SlotView::class, SlotView::SLOT_VALUES);
     }
@@ -224,7 +225,7 @@ class RenderViewHelper extends AbstractConditionViewHelper
     /**
      * @return array
      */
-    protected static function getMarkers()
+    protected static function getMarkers(): array
     {
         return self::$currentVariableContainer->get(SlotView::class, SlotView::MARKERS);
     }

--- a/Classes/ViewHelpers/Slot/SlotViewHelper.php
+++ b/Classes/ViewHelpers/Slot/SlotViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -44,12 +45,12 @@ abstract class SlotViewHelper extends AbstractViewHelper
     /**
      * @return Slot
      */
-    abstract protected function getSlot();
+    abstract protected function getSlot(): Slot;
 
     /**
      * @return string
      */
-    protected function getSlotName()
+    protected function getSlotName(): string
     {
         return $this->arguments['name'];
     }
@@ -57,7 +58,7 @@ abstract class SlotViewHelper extends AbstractViewHelper
     /**
      * @return string
      */
-    protected function getSlotLabel()
+    protected function getSlotLabel(): string
     {
         $label = $this->arguments['label'];
 
@@ -71,7 +72,7 @@ abstract class SlotViewHelper extends AbstractViewHelper
     /**
      * @return SlotContainer
      */
-    protected function getSlotContainer()
+    protected function getSlotContainer(): SlotContainer
     {
         return $this->viewHelperVariableContainer->get(__CLASS__, self::SLOT_CONTAINER);
     }

--- a/Classes/ViewHelpers/Slot/TextViewHelper.php
+++ b/Classes/ViewHelpers/Slot/TextViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018
@@ -35,7 +36,7 @@ class TextViewHelper extends SlotViewHelper
     /**
      * @return Slot
      */
-    protected function getSlot()
+    protected function getSlot(): Slot
     {
         $rte = $this->arguments['rte'];
         $rteMode = $this->arguments['rteMode'];

--- a/Classes/ViewHelpers/TViewHelper.php
+++ b/Classes/ViewHelpers/TViewHelper.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /*
  * Copyright (C) 2018


### PR DESCRIPTION
The extension now uses PHP 7.0 strict types in its API.

Third-party extensions which extend classes of the core may have to 
adapt their code to follow the new methods signatures.