### PR TITLE
[BUGFIX] Repair notification entities translation

### DIFF
--- a/Classes/Core/Notification/TCA/EntityTcaWriter.php
+++ b/Classes/Core/Notification/TCA/EntityTcaWriter.php
@@ -288,7 +288,6 @@ abstract class EntityTcaWriter implements SingletonInterface
                 'exclude' => 1,
                 'label' => self::LLL . ":field.event",
                 'l10n_mode' => 'exclude',
-                'l10n_display' => 'defaultAsReadonly',
                 'config' => [
                     'type' => 'select',
                     'size' => 8,

--- a/Classes/Core/Notification/TCA/Processor/EventConfigurationProcessor.php
+++ b/Classes/Core/Notification/TCA/Processor/EventConfigurationProcessor.php
@@ -34,7 +34,7 @@ class EventConfigurationProcessor extends GracefulProcessor
     protected function doProcess(string $tableName)
     {
         $flexFormDs = [
-            'default' => '',
+            'default' => 'FILE:EXT:notiz/Configuration/FlexForm/Event/Default.xml',
         ];
         $displayConditions = [];
 

--- a/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaWriter.php
+++ b/Classes/Domain/Notification/Email/Application/EntityEmail/TCA/EntityEmailTcaWriter.php
@@ -76,7 +76,7 @@ class EntityEmailTcaWriter extends EntityTcaWriter
                 '0' => [
                     'showitem' => '
                         error_message,
-                        title, description, sys_language_uid, hidden,
+                        title, description, hidden,
                         --div--;' . self::LLL . ':tab.event,
                             event, event_configuration_flex,
                         --div--;' . self::LLL . ':tab.channel,
@@ -165,8 +165,6 @@ class EntityEmailTcaWriter extends EntityTcaWriter
                     'exclude' => 1,
                     'label' => self::EMAIL_LLL . ':field.sender',
                     'displayCond' => 'FIELD:sender_custom:=:1',
-                    'l10n_mode' => 'exclude',
-                    'l10n_display' => 'defaultAsReadonly',
                     'config' => [
                         'type' => 'input',
                         'size' => 255,

--- a/Classes/Domain/Notification/Log/Application/EntityLog/TCA/EntityLogTcaWriter.php
+++ b/Classes/Domain/Notification/Log/Application/EntityLog/TCA/EntityLogTcaWriter.php
@@ -62,7 +62,7 @@ class EntityLogTcaWriter extends EntityTcaWriter
                 '0' => [
                     'showitem' => '
                         error_message,
-                        title, description, sys_language_uid, hidden,
+                        title, description, hidden,
                         --div--;' . self::LLL . ':tab.event,
                             event, event_configuration_flex,
                         --div--;' . self::LLL . ':tab.channel,

--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
@@ -54,7 +54,7 @@ class EntitySlackTcaWriter extends EntityTcaWriter
                 '0' => [
                     'showitem' => '
                 error_message,
-                title, description, sys_language_uid, hidden,
+                title, description, hidden,
                 --div--;' . self::LLL . ':tab.event,
                     event, event_configuration_flex,
                 --div--;' . self::LLL . ':tab.channel,

--- a/Classes/Domain/Repository/EntityNotificationRepository.php
+++ b/Classes/Domain/Repository/EntityNotificationRepository.php
@@ -84,6 +84,9 @@ class EntityNotificationRepository extends Repository
     {
         $query = $this->createQueryWithoutEnableStatement();
 
+        // Do not force the language so the correct notification is returned.
+        $query->getQuerySettings()->setRespectSysLanguage(false);
+
         $query->matching(
             $query->logicalAnd(
                 $query->equals('uid', $identifier),

--- a/Configuration/FlexForm/Event/Default.xml
+++ b/Configuration/FlexForm/Event/Default.xml
@@ -1,0 +1,11 @@
+<T3DataStructure>
+    <sheets>
+        <sDEF>
+            <ROOT>
+                <TCEforms>
+                    <sheetTitle>Default</sheetTitle>
+                </TCEforms>
+            </ROOT>
+        </sDEF>
+    </sheets>
+</T3DataStructure>

--- a/Documentation/07-KnownIssues/Index.rst
+++ b/Documentation/07-KnownIssues/Index.rst
@@ -14,3 +14,19 @@ If this error occurs, a parameter must be changed in the Install Tool.
 In the ``All configuration`` menu, search for ``setDBinit``.
 
 In the ``[SYS][setDBinit]`` textarea, put ``SET SESSION sql_mode=''`` and save.
+
+Notification translation is not working
+---------------------------------------
+
+Unfortunately, TYPO3 8.7 provides inconsistent behaviour with entities
+translations, meaning you may encounter issues when working with translated
+notifications.
+
+At the moment, we do not provide a working solution for this for TYPO3 8.7
+instances. If this is a concern for you, please consider contacting us for
+trying to find a solution together.
+
+.. note::
+
+    TYPO3 9.5 instances are not affected by this issue, notification translation
+    should work fine on these instances.

--- a/Documentation/07-KnownIssues/Index.rst
+++ b/Documentation/07-KnownIssues/Index.rst
@@ -23,8 +23,8 @@ translations, meaning you may encounter issues when working with translated
 notifications.
 
 At the moment, we do not provide a working solution for this for TYPO3 8.7
-instances. If this is a concern for you, please consider contacting us for
-trying to find a solution together.
+instances. If this is a concern for you, please consider contacting us to
+try to find a solution together.
 
 .. note::
 


### PR DESCRIPTION
Some love has been given to the notification translation inside TYPO3
backend.

Unfortunately, since 2ee9d93 the translation is broken on TYPO3 8.7
instances. Because this issue is already fixed with TYPO3 9.5, no fix
has been done yet. Instead, a new section inside the "Known issues"
documentation chapter has been added to explain it.