### PR TITLE
[FEATURE] Introduce event for new comment submission with EXT:blog

### DIFF
--- a/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
+++ b/Classes/Domain/Definition/Builder/Component/DefaultDefinitionComponents.php
@@ -97,6 +97,12 @@ class DefaultDefinitionComponents implements SingletonInterface
             $defaultFiles[] = NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Form.typoscript';
         }
 
+        if (ExtensionManagementUtility::isLoaded('blog')
+            && version_compare(ExtensionManagementUtility::getExtensionVersion('blog'), '9.0.0', '>')
+        ) {
+            $defaultFiles[] = NotizConstants::TYPOSCRIPT_PATH . 'Event/Events.Blog.typoscript';
+        }
+
         return $defaultFiles;
     }
 }

--- a/Classes/Domain/Event/Blog/CommentAddedEvent.php
+++ b/Classes/Domain/Event/Blog/CommentAddedEvent.php
@@ -18,11 +18,14 @@ declare(strict_types=1);
 namespace CuyZ\Notiz\Domain\Event\Blog;
 
 use CuyZ\Notiz\Core\Event\AbstractEvent;
+use CuyZ\Notiz\Core\Event\Support\ProvidesExampleProperties;
+use DateTime;
 use T3G\AgencyPack\Blog\Domain\Model\Comment;
 use T3G\AgencyPack\Blog\Domain\Model\Post;
 use T3G\AgencyPack\Blog\Notification\CommentAddedNotification;
+use TYPO3\CMS\Extbase\Domain\Model\FrontendUser;
 
-class CommentAddedEvent extends AbstractEvent
+class CommentAddedEvent extends AbstractEvent implements ProvidesExampleProperties
 {
     /**
      * @label Event/Blog:comment_added.marker.comment
@@ -59,5 +62,36 @@ class CommentAddedEvent extends AbstractEvent
         $this->post = $data['post'];
 
         $this->commentEmail = $this->comment->getEmail();
+    }
+
+    /**
+     * @return array
+     */
+    public function getExampleProperties(): array
+    {
+        $author = new FrontendUser();
+        $author->setName('John Doe');
+
+        $post = new Post();
+        $post->setTitle('My awesome post!');
+        $post->setSubtitle('This is so awesome!');
+        $post->setAbstract('The abstract of my post');
+        $post->setDescription('Some awesome description for an awesome post.');
+        $post->setCrdate(new DateTime());
+
+        $comment = new Comment();
+        $comment->setAuthor($author);
+        $comment->setName('Some comment');
+        $comment->setEmail('john.doe@example.com');
+        $comment->setUrl('https://example.com');
+        $comment->setComment('This is an awesome comment!');
+        $comment->setPost($post);
+        $comment->setCrdate(new DateTime());
+
+        return [
+            'comment' => $comment,
+            'post' => $post,
+            'commentEmail' => 'john.doe@example.com',
+        ];
     }
 }

--- a/Classes/Domain/Event/Blog/CommentAddedEvent.php
+++ b/Classes/Domain/Event/Blog/CommentAddedEvent.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Domain\Event\Blog;
+
+use CuyZ\Notiz\Core\Event\AbstractEvent;
+use T3G\AgencyPack\Blog\Domain\Model\Comment;
+use T3G\AgencyPack\Blog\Domain\Model\Post;
+use T3G\AgencyPack\Blog\Notification\CommentAddedNotification;
+
+class CommentAddedEvent extends AbstractEvent
+{
+    /**
+     * @label Event/Blog:comment_added.marker.comment
+     * @marker
+     *
+     * @var Comment
+     */
+    protected $comment;
+
+    /**
+     * @label Event/Blog:comment_added.marker.post
+     * @marker
+     *
+     * @var Post
+     */
+    protected $post;
+
+    /**
+     * @label Event/Blog:comment_added.email.comment_email
+     * @email
+     *
+     * @var array
+     */
+    protected $commentEmail;
+
+    /**
+     * @param CommentAddedNotification $commentAddedNotification
+     */
+    public function run(CommentAddedNotification $commentAddedNotification)
+    {
+        $data = $commentAddedNotification->getData();
+
+        $this->comment = $data['comment'];
+        $this->post = $data['post'];
+
+        $this->commentEmail = $this->comment->getEmail();
+    }
+}

--- a/Classes/Domain/Event/Blog/Processor/BlogNotificationProcessor.php
+++ b/Classes/Domain/Event/Blog/Processor/BlogNotificationProcessor.php
@@ -1,0 +1,48 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Copyright (C) 2018
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Domain\Event\Blog\Processor;
+
+use T3G\AgencyPack\Blog\Notification\NotificationInterface;
+use T3G\AgencyPack\Blog\Notification\Processor\ProcessorInterface;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
+
+class BlogNotificationProcessor implements ProcessorInterface, SingletonInterface
+{
+    /**
+     * @var Dispatcher
+     */
+    protected $dispatcher;
+
+    /**
+     * Manual dependency injection.
+     */
+    public function __construct()
+    {
+        $this->dispatcher = GeneralUtility::makeInstance(Dispatcher::class);
+    }
+
+    /**
+     * @param NotificationInterface $notification
+     */
+    public function process(NotificationInterface $notification)
+    {
+        $this->dispatcher->dispatch(self::class, $notification->getNotificationId(), [$notification]);
+    }
+}

--- a/Classes/Service/Extension/LocalConfigurationService.php
+++ b/Classes/Service/Extension/LocalConfigurationService.php
@@ -25,11 +25,13 @@ use CuyZ\Notiz\Core\Definition\Builder\DefinitionBuilder;
 use CuyZ\Notiz\Core\Notification\TCA\Processor\GracefulProcessorRunner;
 use CuyZ\Notiz\Core\Support\NotizConstants;
 use CuyZ\Notiz\Domain\Definition\Builder\Component\DefaultDefinitionComponents;
+use CuyZ\Notiz\Domain\Event\Blog\Processor\BlogNotificationProcessor;
 use CuyZ\Notiz\Service\Container;
 use CuyZ\Notiz\Service\ExtensionConfigurationService;
 use CuyZ\Notiz\Service\Hook\EventDefinitionRegisterer;
 use CuyZ\Notiz\Service\Traits\SelfInstantiateTrait;
 use Doctrine\Common\Annotations\AnnotationReader;
+use T3G\AgencyPack\Blog\Notification\CommentAddedNotification;
 use TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseEditRow;
 use TYPO3\CMS\Backend\Form\FormDataProvider\DatabaseRecordOverrideValues;
 use TYPO3\CMS\Backend\Form\FormDataProvider\InitializeProcessedTca;
@@ -94,6 +96,7 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
         $this->resetTypeConvertersArray();
         $this->overrideScheduler();
         $this->ignoreDoctrineAnnotation();
+        $this->registerBlogNotificationProcessors();
     }
 
     /**
@@ -276,6 +279,18 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
             AnnotationReader::addGlobalIgnoredName('label');
             AnnotationReader::addGlobalIgnoredName('marker');
             AnnotationReader::addGlobalIgnoredName('email');
+        }
+    }
+
+    /**
+     * Registering a blog processor for each notification it provides.
+     */
+    protected function registerBlogNotificationProcessors()
+    {
+        if (ExtensionManagementUtility::isLoaded('blog')
+            && version_compare(ExtensionManagementUtility::getExtensionVersion('blog'), '9.0.0', '>')
+        ) {
+            $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['Blog']['notificationRegistry'][CommentAddedNotification::class][] = BlogNotificationProcessor::class;
         }
     }
 }

--- a/Configuration/TypoScript/Event/Events.Blog.typoscript
+++ b/Configuration/TypoScript/Event/Events.Blog.typoscript
@@ -1,0 +1,30 @@
+notiz {
+    eventGroups {
+        blog {
+            label = Event/Blog:event_group.title
+
+            events {
+                /*
+                * A comment is added
+                * ------------------
+                *
+                * This event is triggered when a user submits a new comment on a
+                * blog post
+                */
+                commentAdded {
+                    label = Event/Blog:comment_added.title
+                    description = Event/Blog:comment_added.description
+
+                    className = CuyZ\Notiz\Domain\Event\Blog\CommentAddedEvent
+
+                    connection {
+                        type = signal
+
+                        className = CuyZ\Notiz\Domain\Event\Blog\Processor\BlogNotificationProcessor
+                        name = T3G\AgencyPack\Blog\Notification\CommentAddedNotification
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Documentation/05-Event/ProvidedEvent/04-Blog/CommentAdded.rst
+++ b/Documentation/05-Event/ProvidedEvent/04-Blog/CommentAdded.rst
@@ -1,0 +1,38 @@
+.. include:: ../../../Includes.txt
+
+Blog – A new comment is submitted
+=================================
+
+.. important::
+
+    To use this event, the `Blog extension`_ must be installed and active with
+    at least version ``9.0.0``.
+
+.. _Blog extension: https://docs.typo3.org/typo3cms/extensions/blog/Index.html
+
+-----
+
+This event is triggered when a user submits a new comment on a blog post.
+
+The following properties can be used in notifications:
+
+
+==================== ===========================================================
+Property             Description
+==================== ===========================================================
+comment              The comment that was added by the user. It contains the
+                     data that was submitted.
+
+                     .. note::
+
+                         This property contains an instance of the class
+                         :php:`\T3G\AgencyPack\Blog\Domain\Model\Comment`.
+
+post                 The post on which the comment was submitted. It contains
+                     useful information such as the post title.
+
+                     .. note::
+
+                         This property contains an instance of the class
+                         :php:`\T3G\AgencyPack\Blog\Domain\Model\Post`.
+==================== ===========================================================

--- a/Resources/Private/Language/Event/Blog/Blog.xlf
+++ b/Resources/Private/Language/Event/Blog/Blog.xlf
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<xliff version="1.0">
+    <file source-language="en">
+        <header/>
+        <body>
+
+            <trans-unit id="event_group.title">
+                <source>Blog</source>
+            </trans-unit>
+
+            <!--#########################-->
+            <!--###   COMMENT ADDED   ###-->
+            <!--#########################-->
+
+            <trans-unit id="comment_added.title">
+                <source>A comment is submitted</source>
+            </trans-unit>
+            <trans-unit id="comment_added.description">
+                <source>This event will be triggered whenever a user submits a comment on a blog post.</source>
+            </trans-unit>
+
+            <trans-unit id="comment_added.marker.comment">
+                <source>The comment that was submitted by the user.</source>
+            </trans-unit>
+            <trans-unit id="comment_added.marker.post">
+                <source>The post on which the comment was submitted by the user.</source>
+            </trans-unit>
+            <trans-unit id="comment_added.email.comment_email">
+                <source>Email submitted in the comment</source>
+            </trans-unit>
+
+        </body>
+    </file>
+</xliff>


### PR DESCRIPTION
A new event is added, it is triggered whenever a user submits a new
comment on a blog post.

Both the comment and the post data can be used within a notification.