### PR TITLE
[TASK] Make Slack additional channel not required

### DIFF
--- a/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
+++ b/Classes/Domain/Notification/Slack/Application/EntitySlack/TCA/EntitySlackTcaWriter.php
@@ -185,7 +185,7 @@ class EntitySlackTcaWriter extends EntityTcaWriter
                     'config' => [
                         'type' => 'input',
                         'size' => 255,
-                        'eval' => 'trim,required',
+                        'eval' => 'trim',
                     ],
                 ],
 
@@ -195,7 +195,7 @@ class EntitySlackTcaWriter extends EntityTcaWriter
                     'config' => [
                         'type' => 'input',
                         'size' => 255,
-                        'eval' => 'trim,required',
+                        'eval' => 'trim',
                     ],
                 ],
 


### PR DESCRIPTION
Because another field (`slack_channel`) can be used to select a channel
where to send the Slack message, the additional channel has no reason to
be required.

Fixes #204