### PR TITLE
[BUGFIX] Use middleware for event definition registration

### DIFF
--- a/Classes/Middleware/EventDefinitionRegistererMiddleware.php
+++ b/Classes/Middleware/EventDefinitionRegistererMiddleware.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Copyright (C)
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Middleware;
+
+use CuyZ\Notiz\Service\Hook\EventDefinitionRegisterer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+class EventDefinitionRegistererMiddleware implements MiddlewareInterface
+{
+    /**
+     * @param ServerRequestInterface $request
+     * @param RequestHandlerInterface $handler
+     * @return ResponseInterface
+     */
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        GeneralUtility::makeInstance(EventDefinitionRegisterer::class)->processData();
+
+        return $handler->handle($request);
+    }
+}

--- a/Classes/Service/Extension/LocalConfigurationService.php
+++ b/Classes/Service/Extension/LocalConfigurationService.php
@@ -44,8 +44,11 @@ use TYPO3\CMS\Core\Imaging\IconRegistry;
 use TYPO3\CMS\Core\SingletonInterface;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Core\Utility\VersionNumberUtility;
 use TYPO3\CMS\Extbase\SignalSlot\Dispatcher;
 use TYPO3\CMS\Scheduler\Scheduler;
+
+use function version_compare;
 
 /**
  * This class replaces the old-school procedural way of handling configuration
@@ -143,8 +146,10 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
      */
     protected function registerEventDefinitionHook()
     {
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['extTablesInclusion-PostProcessing'][] = EventDefinitionRegisterer::class;
-        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc'][] = EventDefinitionRegisterer::class . '->processData';
+        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '9.5.0', '<')) {
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['extTablesInclusion-PostProcessing'][] = EventDefinitionRegisterer::class;
+            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc'][] = EventDefinitionRegisterer::class . '->processData';
+        }
     }
 
     /**

--- a/Classes/Service/Hook/EventDefinitionRegisterer.php
+++ b/Classes/Service/Hook/EventDefinitionRegisterer.php
@@ -32,6 +32,9 @@ use TYPO3\CMS\Core\SingletonInterface;
  *
  * We get there to register events (signals, hooks) that were added to the
  * definition.
+ *
+ * @deprecated Must be moved when TYPO3 v8 is not supported anymore.
+ * @see \CuyZ\Notiz\Middleware\EventDefinitionRegistererMiddleware
  */
 class EventDefinitionRegisterer implements SingletonInterface, TableConfigurationPostProcessingHookInterface
 {

--- a/Configuration/RequestMiddlewares.php
+++ b/Configuration/RequestMiddlewares.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (C)
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+return [
+    'frontend' => [
+        'cuyz/notiz/events-registration' => [
+            'target' => \CuyZ\Notiz\Middleware\EventDefinitionRegistererMiddleware::class,
+            'before' => [
+                'typo3/cms-frontend/preprocessing'
+            ],
+        ],
+    ],
+    'backend' => [
+        'cuyz/notiz/events-registration' => [
+            'target' => \CuyZ\Notiz\Middleware\EventDefinitionRegistererMiddleware::class,
+            'before' => [
+                'typo3/cms-backend/locked-backend'
+            ],
+        ],
+    ],
+];


### PR DESCRIPTION
With TYPO3 v9.5+ hooks have been deprecated in favor of middleware
usage. Some hooks would event not run like they used to in former
versions.

This commit introduces a new middleware (which is used both in frontend
and backend) to register the event definitions.