### PR TITLE
[FEATURE] Introduce event for record creation/update

### DIFF
--- a/Classes/Domain/Event/TYPO3/RecordCreatedEvent.php
+++ b/Classes/Domain/Event/TYPO3/RecordCreatedEvent.php
@@ -20,7 +20,6 @@ namespace CuyZ\Notiz\Domain\Event\TYPO3;
 use CuyZ\Notiz\Core\Event\AbstractEvent;
 use CuyZ\Notiz\Core\Event\Support\ProvidesExampleProperties;
 use InvalidArgumentException;
-use TYPO3\CMS\Backend\Utility\BackendUtility;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 
 final class RecordCreatedEvent extends AbstractEvent implements ProvidesExampleProperties
@@ -65,13 +64,13 @@ final class RecordCreatedEvent extends AbstractEvent implements ProvidesExampleP
 
         if ($status === 'new') {
             $this->uid = $dataHandler->substNEWwithIDs[$recordId];
-            $this->record = $updatedFields;
         } elseif ($status === 'update') {
             $this->uid = $recordId;
-            $this->record = BackendUtility::getRecord($table, $recordId);
         } else {
             throw new InvalidArgumentException('$status must be `new` or `update`');
         }
+
+        $this->record = $dataHandler->recordInfo($table, $this->uid, '*');
 
         if ($table === 'tt_content'
             && !empty($this->configuration['ctype'])

--- a/Classes/Domain/Event/TYPO3/RecordCreatedEvent.php
+++ b/Classes/Domain/Event/TYPO3/RecordCreatedEvent.php
@@ -1,0 +1,99 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Copyright (C)
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Domain\Event\TYPO3;
+
+use CuyZ\Notiz\Core\Event\AbstractEvent;
+use CuyZ\Notiz\Core\Event\Support\ProvidesExampleProperties;
+use InvalidArgumentException;
+use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+
+final class RecordCreatedEvent extends AbstractEvent implements ProvidesExampleProperties
+{
+    /**
+     * @label Event/TYPO3:record_created.marker.status
+     * @marker
+     *
+     * @var string
+     */
+    protected $status;
+
+    /**
+     * @label Event/TYPO3:record_created.marker.table
+     * @marker
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * @label Event/TYPO3:record_created.marker.uid
+     * @marker
+     *
+     * @var string
+     */
+    protected $uid;
+
+    /**
+     * @label Event/TYPO3:record_created.marker.record
+     * @marker
+     *
+     * @var array
+     */
+    protected $record;
+
+    public function run($status, $table, $recordId, array $updatedFields, DataHandler $dataHandler)
+    {
+        if ($table !== $this->configuration['table']) {
+            $this->cancelDispatch();
+        }
+
+        if ($status === 'new') {
+            $this->uid = $dataHandler->substNEWwithIDs[$recordId];
+            $this->record = $updatedFields;
+        } elseif ($status === 'update') {
+            $this->uid = $recordId;
+            $this->record = BackendUtility::getRecord($table, $recordId);
+        } else {
+            throw new InvalidArgumentException('$status must be `new` or `update`');
+        }
+
+        if ($table === 'tt_content'
+            && !preg_match($this->configuration['ctype'], $this->record['CType'])
+        ) {
+            $this->cancelDispatch();
+        }
+
+        $this->status = $status;
+        $this->table = $table;
+    }
+
+    public function getExampleProperties(): array
+    {
+        return [
+            'status' => 'new',
+            'table' => $this->configuration['table'],
+            'uid' => 1337,
+            'record' => [
+                'uid' => 1337,
+                'pid' => 42,
+                'starttime' => 1612014706,
+            ],
+        ];
+    }
+}

--- a/Classes/Domain/Event/TYPO3/RecordCreatedEvent.php
+++ b/Classes/Domain/Event/TYPO3/RecordCreatedEvent.php
@@ -164,7 +164,19 @@ final class RecordCreatedEvent extends AbstractEvent implements ProvidesExampleP
 
         $authorizedPids = explode(',', $this->configuration['pids']);
 
-        $currentPid = $this->record['pid'];
+        $currentPid = (int)$this->record['pid'];
+
+        if ($currentPid === 0) {
+            if (count($authorizedPids) === 0) {
+                return;
+            }
+
+            if (in_array($currentPid, $authorizedPids)) {
+                return;
+            }
+
+            $this->cancelDispatch();
+        }
 
         /** @var ObjectManager $objectManager */
         $objectManager = GeneralUtility::makeInstance(ObjectManager::class);

--- a/Classes/Domain/Event/TYPO3/RecordCreatedEvent.php
+++ b/Classes/Domain/Event/TYPO3/RecordCreatedEvent.php
@@ -74,6 +74,7 @@ final class RecordCreatedEvent extends AbstractEvent implements ProvidesExampleP
         }
 
         if ($table === 'tt_content'
+            && !empty($this->configuration['ctype'])
             && !preg_match($this->configuration['ctype'], $this->record['CType'])
         ) {
             $this->cancelDispatch();

--- a/Classes/Service/Extension/LocalConfigurationService.php
+++ b/Classes/Service/Extension/LocalConfigurationService.php
@@ -29,6 +29,7 @@ use CuyZ\Notiz\Domain\Event\Blog\Processor\BlogNotificationProcessor;
 use CuyZ\Notiz\Service\Container;
 use CuyZ\Notiz\Service\ExtensionConfigurationService;
 use CuyZ\Notiz\Service\Hook\EventDefinitionRegisterer;
+use CuyZ\Notiz\Service\TCA\TcaRegexEval;
 use CuyZ\Notiz\Service\Traits\SelfInstantiateTrait;
 use Doctrine\Common\Annotations\AnnotationReader;
 use T3G\AgencyPack\Blog\Notification\CommentAddedNotification;
@@ -100,6 +101,7 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
         $this->overrideScheduler();
         $this->ignoreDoctrineAnnotation();
         $this->registerBlogNotificationProcessors();
+        $this->registerTcaEvalClasses();
     }
 
     /**
@@ -297,5 +299,10 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
         ) {
             $GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['Blog']['notificationRegistry'][CommentAddedNotification::class][] = BlogNotificationProcessor::class;
         }
+    }
+
+    protected function registerTcaEvalClasses()
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tce']['formevals'][TcaRegexEval::class] = '';
     }
 }

--- a/Classes/Service/TCA/TcaRegexEval.php
+++ b/Classes/Service/TCA/TcaRegexEval.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Copyright (C)
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Service\TCA;
+
+use CuyZ\Notiz\Service\LocalizationService;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\SingletonInterface;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+use function preg_last_error;
+use function preg_match;
+
+final class TcaRegexEval implements SingletonInterface
+{
+    /**
+     * Will check if the given value has a correct regex syntax. Sends a flash
+     * message and resets the value if not.
+     *
+     * @param string $value
+     * @return string
+     */
+    public function evaluateFieldValue($value)
+    {
+        if (empty($value)) {
+            return $value;
+        }
+
+        preg_match($value, '');
+
+        if (preg_last_error() === PREG_NO_ERROR) {
+            return $value;
+        }
+
+        $message = GeneralUtility::makeInstance(
+            FlashMessage::class,
+            LocalizationService::localize('Backend/TCA:regex_error.description', [$value]),
+            LocalizationService::localize('Backend/TCA:regex_error.title'),
+            FlashMessage::ERROR
+        );
+
+        $flashMessageService = GeneralUtility::makeInstance(FlashMessageService::class);
+        $messageQueue = $flashMessageService->getMessageQueueByIdentifier();
+        $messageQueue->addMessage($message);
+
+        return '';
+    }
+}

--- a/Classes/Service/TCAService.php
+++ b/Classes/Service/TCAService.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * Copyright (C)
+ * Nathan Boiron <nathan.boiron@gmail.com>
+ * Romain Canon <romain.hydrocanon@gmail.com>
+ *
+ * This file is part of the TYPO3 NotiZ project.
+ * It is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License, either
+ * version 3 of the License, or any later version.
+ *
+ * For the full copyright and license information, see:
+ * http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace CuyZ\Notiz\Service;
+
+use TYPO3\CMS\Core\SingletonInterface;
+
+final class TCAService implements SingletonInterface
+{
+    public function getTablesList(array &$parameters)
+    {
+        $tables = array_map(function ($table) {
+            return [$table, $table];
+        }, array_keys($GLOBALS['TCA']));
+
+        sort($tables);
+
+        $parameters['items'] = $tables;
+    }
+}

--- a/Configuration/FlexForm/Event/TYPO3/RecordCreatedEventFlexForm.xml
+++ b/Configuration/FlexForm/Event/TYPO3/RecordCreatedEventFlexForm.xml
@@ -56,6 +56,20 @@
                             </config>
                         </TCEforms>
                     </statuses>
+
+                    <pids>
+                        <TCEforms>
+                            <label>LLL:EXT:notiz/Resources/Private/Language/Event/TYPO3/TYPO3.xlf:record_created.flex_form.pids.label</label>
+                            <config>
+                                <type>group</type>
+                                <internal_type>db</internal_type>
+                                <allowed>pages</allowed>
+                                <minitems>0</minitems>
+                                <maxitems>10</maxitems>
+                                <size>2</size>
+                            </config>
+                        </TCEforms>
+                    </pids>
                 </el>
             </ROOT>
         </sDEF>

--- a/Configuration/FlexForm/Event/TYPO3/RecordCreatedEventFlexForm.xml
+++ b/Configuration/FlexForm/Event/TYPO3/RecordCreatedEventFlexForm.xml
@@ -30,6 +30,7 @@
                             <displayCond>FIELD:table:=:tt_content</displayCond>
                             <config>
                                 <type>input</type>
+                                <eval>CuyZ\Notiz\Service\TCA\TcaRegexEval</eval>
                             </config>
                         </TCEforms>
                     </ctype>

--- a/Configuration/FlexForm/Event/TYPO3/RecordCreatedEventFlexForm.xml
+++ b/Configuration/FlexForm/Event/TYPO3/RecordCreatedEventFlexForm.xml
@@ -1,0 +1,40 @@
+<T3DataStructure>
+    <meta>
+        <langChildren>0</langChildren>
+    </meta>
+    <sheets>
+        <sDEF>
+            <ROOT>
+                <TCEforms>
+                    <sheetTitle>Event: record created</sheetTitle>
+                </TCEforms>
+                <type>array</type>
+                <el>
+                    <table>
+                        <TCEforms>
+                            <label>LLL:EXT:notiz/Resources/Private/Language/Event/TYPO3/TYPO3.xlf:record_created.flex_form.table.label</label>
+                            <onChange>reload</onChange>
+                            <config>
+                                <type>select</type>
+                                <renderType>selectSingle</renderType>
+                                <itemsProcFunc>CuyZ\Notiz\Service\TCAService->getTablesList</itemsProcFunc>
+                                <size>10</size>
+                                <eval>required</eval>
+                            </config>
+                        </TCEforms>
+                    </table>
+
+                    <ctype>
+                        <TCEforms>
+                            <label>LLL:EXT:notiz/Resources/Private/Language/Event/TYPO3/TYPO3.xlf:record_created.flex_form.ctype.label</label>
+                            <displayCond>FIELD:table:=:tt_content</displayCond>
+                            <config>
+                                <type>input</type>
+                            </config>
+                        </TCEforms>
+                    </ctype>
+                </el>
+            </ROOT>
+        </sDEF>
+    </sheets>
+</T3DataStructure>

--- a/Configuration/FlexForm/Event/TYPO3/RecordCreatedEventFlexForm.xml
+++ b/Configuration/FlexForm/Event/TYPO3/RecordCreatedEventFlexForm.xml
@@ -34,6 +34,28 @@
                             </config>
                         </TCEforms>
                     </ctype>
+
+                    <statuses>
+                        <TCEforms>
+                            <label>LLL:EXT:notiz/Resources/Private/Language/Event/TYPO3/TYPO3.xlf:record_created.flex_form.statuses.label</label>
+                            <config>
+                                <type>select</type>
+                                <minitems>0</minitems>
+                                <maxitems>2</maxitems>
+                                <size>2</size>
+                                <items type="array">
+                                    <numIndex index="0" type="array">
+                                        <numIndex index="0">LLL:EXT:notiz/Resources/Private/Language/Event/TYPO3/TYPO3.xlf:record_created.flex_form.statuses.new.label</numIndex>
+                                        <numIndex index="1">new</numIndex>
+                                    </numIndex>
+                                    <numIndex index="1" type="array">
+                                        <numIndex index="0">LLL:EXT:notiz/Resources/Private/Language/Event/TYPO3/TYPO3.xlf:record_created.flex_form.statuses.update.label</numIndex>
+                                        <numIndex index="1">update</numIndex>
+                                    </numIndex>
+                                </items>
+                            </config>
+                        </TCEforms>
+                    </statuses>
                 </el>
             </ROOT>
         </sDEF>

--- a/Configuration/TypoScript/Event/Events.TYPO3.typoscript
+++ b/Configuration/TypoScript/Event/Events.TYPO3.typoscript
@@ -52,6 +52,27 @@ notiz {
                         path = t3lib/class.t3lib_tcemain.php|clearCachePostProc
                     }
                 }
+
+                recordCreated {
+                    label = Event/TYPO3:record_created.title
+                    description = Event/TYPO3:record_created.description
+
+                    className = CuyZ\Notiz\Domain\Event\TYPO3\RecordCreatedEvent
+
+                    configuration {
+                        flexForm {
+                            file = EXT:notiz/Configuration/FlexForm/Event/TYPO3/RecordCreatedEventFlexForm.xml
+                        }
+                    }
+
+                    connection {
+                        type = hook
+
+                        path = t3lib/class.t3lib_tcemain.php|processDatamapClass
+
+                        method = processDatamap_afterDatabaseOperations
+                    }
+                }
             }
         }
     }

--- a/Documentation/05-Event/ProvidedEvent/01-TYPO3/RecordCreated.rst
+++ b/Documentation/05-Event/ProvidedEvent/01-TYPO3/RecordCreated.rst
@@ -1,0 +1,24 @@
+.. include:: ../../../Includes.txt
+
+TYPO3 – Record created/updated
+==============================
+
+This event is fired when any record is created/updated within the TYPO3 backend.
+
+You must select which record type will fire the event, for instance
+``tt_content``.
+
+If you selected ``tt_content``, you shall also filter which type of record will
+be filtered by filling the filter field with a valid regex, for instance
+``/text(pic)?/``.
+
+The following properties can be used in notifications:
+
+============ ===================================================================
+Property     Description
+============ ===================================================================
+status       Status of the record, either ``new`` or ``update``
+table        Table of the record, for instance ``tt_content``
+uid          Record uid
+record       Raw record array
+============ ===================================================================

--- a/Resources/Private/Language/Backend/TCA/TCA.xlf
+++ b/Resources/Private/Language/Backend/TCA/TCA.xlf
@@ -11,6 +11,13 @@
                 <source>An error occurred, the notification can not be edited. #LF# If the problem persists, contact your administrator.</source>
             </trans-unit>
 
+            <trans-unit id="regex_error.title">
+                <source>Invalid regex</source>
+            </trans-unit>
+            <trans-unit id="regex_error.description">
+                <source>The regex `%s` is invalid, please check the syntax again.</source>
+            </trans-unit>
+
             <!--####################################-->
             <!--###  SLACK TCA - NO BOT DEFINED  ###-->
             <!--####################################-->

--- a/Resources/Private/Language/Event/TYPO3/TYPO3.xlf
+++ b/Resources/Private/Language/Event/TYPO3/TYPO3.xlf
@@ -56,6 +56,15 @@
             <trans-unit id="record_created.flex_form.ctype.label">
                 <source>Filter on the content type (CType). Must be a valid regex, for instance `/text(pic)?/`</source>
             </trans-unit>
+            <trans-unit id="record_created.flex_form.statuses.label">
+                <source>Save type (both by default)</source>
+            </trans-unit>
+            <trans-unit id="record_created.flex_form.statuses.new.label">
+                <source>Creation</source>
+            </trans-unit>
+            <trans-unit id="record_created.flex_form.statuses.update.label">
+                <source>Update</source>
+            </trans-unit>
 
             <trans-unit id="record_created.marker.status">
                 <source>Save status (`new` or `update`)</source>

--- a/Resources/Private/Language/Event/TYPO3/TYPO3.xlf
+++ b/Resources/Private/Language/Event/TYPO3/TYPO3.xlf
@@ -65,6 +65,9 @@
             <trans-unit id="record_created.flex_form.statuses.update.label">
                 <source>Update</source>
             </trans-unit>
+            <trans-unit id="record_created.flex_form.pids.label">
+                <source>Pages (and their subpages) to watch. Leave blank to watch all pages.</source>
+            </trans-unit>
 
             <trans-unit id="record_created.marker.status">
                 <source>Save status (`new` or `update`)</source>

--- a/Resources/Private/Language/Event/TYPO3/TYPO3.xlf
+++ b/Resources/Private/Language/Event/TYPO3/TYPO3.xlf
@@ -43,6 +43,33 @@
                 <source>Version of the extension, for instance `1.4.2`.</source>
             </trans-unit>
 
+            <trans-unit id="record_created.title">
+                <source>Record created or updated</source>
+            </trans-unit>
+            <trans-unit id="record_created.description">
+                <source>This event will be triggered when any record is created or updated.</source>
+            </trans-unit>
+
+            <trans-unit id="record_created.flex_form.table.label">
+                <source>Record table</source>
+            </trans-unit>
+            <trans-unit id="record_created.flex_form.ctype.label">
+                <source>Filter on the content type (CType). Must be a valid regex, for instance `/text(pic)?/`</source>
+            </trans-unit>
+
+            <trans-unit id="record_created.marker.status">
+                <source>Save status (`new` or `update`)</source>
+            </trans-unit>
+            <trans-unit id="record_created.marker.table">
+                <source>Record table, for instance `tt_content`</source>
+            </trans-unit>
+            <trans-unit id="record_created.marker.uid">
+                <source>Record uid</source>
+            </trans-unit>
+            <trans-unit id="record_created.marker.record">
+                <source>Raw record array</source>
+            </trans-unit>
+
         </body>
     </file>
 </xliff>


### PR DESCRIPTION
Allows to send a notification when any record type is created or updated

If the record is from the `tt_content` table, the `CType` column can be
used as a filter to trigger the event (with a regex).