### PR TITLE
[BUGFIX] Trigger event definition registration in more contexts

### DIFF
--- a/Classes/Service/Extension/LocalConfigurationService.php
+++ b/Classes/Service/Extension/LocalConfigurationService.php
@@ -146,10 +146,8 @@ class LocalConfigurationService implements SingletonInterface, TableConfiguratio
      */
     protected function registerEventDefinitionHook()
     {
-        if (version_compare(VersionNumberUtility::getCurrentTypo3Version(), '9.5.0', '<')) {
-            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['extTablesInclusion-PostProcessing'][] = EventDefinitionRegisterer::class;
-            $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc'][] = EventDefinitionRegisterer::class . '->processData';
-        }
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['GLOBAL']['extTablesInclusion-PostProcessing'][] = EventDefinitionRegisterer::class;
+        $GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['checkAlternativeIdMethods-PostProc'][] = EventDefinitionRegisterer::class . '->processData';
     }
 
     /**


### PR DESCRIPTION
In some context — for instance in a CLI request — middlewares do not
run, meaning the event definition registration is not done. Because the
initialization will be run only once in any case, old hooks are used to
ensure a proper registration.

Fixes #234